### PR TITLE
fix build error in release mode with gcc10

### DIFF
--- a/include/my_hash_combine.h
+++ b/include/my_hash_combine.h
@@ -61,12 +61,14 @@ Steinar */
 #define MY_FUNCTIONAL_HASH_ROTL32(x, r) (x << r) | (x >> (32 - r))
 #endif /* _MSC_VER */
 
+#include <stdint.h>
+
 template <typename SizeT>
 inline void my_hash_combine(SizeT &seed, SizeT value) {
   seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
-inline void my_hash_combine(std::uint32_t &h1, std::uint32_t k1) {
+inline void my_hash_combine(uint32_t &h1, uint32_t k1) {
   const uint32_t c1 = 0xcc9e2d51;
   const uint32_t c2 = 0x1b873593;
 
@@ -79,8 +81,8 @@ inline void my_hash_combine(std::uint32_t &h1, std::uint32_t k1) {
   h1 = h1 * 5 + 0xe6546b64;
 }
 
-inline void my_hash_combine(std::uint64_t &h, std::uint64_t k) {
-  const std::uint64_t m = 0xc6a4a7935bd1e995ull;
+inline void my_hash_combine(uint64_t &h, uint64_t k) {
+  const uint64_t m = 0xc6a4a7935bd1e995ull;
   const int r = 47;
 
   k *= m;

--- a/sql/rpl_applier_reader.cc
+++ b/sql/rpl_applier_reader.cc
@@ -70,7 +70,7 @@ class Rpl_applier_reader::Stage_controller {
   }
 
   void enter_stage() {
-    DBUG_ASSERT(m_state = LOCKED);
+    DBUG_ASSERT(m_state == LOCKED);
     m_thd->ENTER_COND(m_cond, m_mutex, &m_new_stage, &m_old_stage);
     m_state = IN_STAGE;
   }

--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -356,12 +356,12 @@ void Binlog_sender::run() {
   if (reader.is_open()) {
     if (is_fatal_error()) {
       /* output events range to error message */
-      snprintf(error_text, sizeof(error_text),
-               "%s; the first event '%s' at %lld, "
-               "the last event read from '%s' at %lld, "
-               "the last byte read from '%s' at %lld.",
-               m_errmsg, m_start_file, m_start_pos, m_last_file, m_last_pos,
-               log_file, reader.position());
+      my_snprintf_8bit(nullptr, error_text, sizeof(error_text),
+                       "%s; the first event '%s' at %lld, "
+                       "the last event read from '%s' at %lld, "
+                       "the last byte read from '%s' at %lld.",
+                       m_errmsg, m_start_file, m_start_pos, m_last_file,
+                       m_last_pos, log_file, reader.position());
       set_fatal_error(error_text);
     }
 

--- a/sql/rpl_utility.h
+++ b/sql/rpl_utility.h
@@ -28,6 +28,7 @@
 #endif
 
 #include <sys/types.h>
+#include <string>
 #include <unordered_map>
 
 #include "field_types.h"  // enum_field_types

--- a/sql/udpsvr.cc
+++ b/sql/udpsvr.cc
@@ -143,7 +143,7 @@ void CUdpServer::loopdealreq() {
                 fprintf(stderr, "recvfrom received %d bytes, equals to message buffer size(%d), "
                         "from int ip:%u, data may be truncated.",
                          ret, recvlen, from.sin_addr.s_addr);
-            strncpy(fromaddr, inet_ntoa(from.sin_addr), 24);
+            strncpy(fromaddr, inet_ntoa(from.sin_addr), strlen(fromaddr));
             do_request(recvbuf, ret, fromaddr);
         } else {
             fprintf(stderr, "recvfrom ret:%d<=0,errno:%d,errstr:%s,from int ip:%u",


### PR DESCRIPTION
fix following errors

--- 

```c++
/data/workspace/code/TXSQL/sql/rpl_applier_reader.cc: In member function ‘void Rpl_applier_reader::Stage_controller::enter_stage()’:                                                                                                                           /data/workspace/code/TXSQL/sql/rpl_applier_reader.cc:73:25: error: suggest parentheses around assignment used as truth value [-Werror=parentheses]
   73 |     DBUG_ASSERT(m_state = LOCKED);
      |                 ~~~~~~~~^~~~~~~~
/data/workspace/code/TXSQL/sql/rpl_applier_reader.cc:73:5: note: in expansion of macro ‘DBUG_ASSERT’
   73 |     DBUG_ASSERT(m_state = LOCKED);                                                                                                                                                                                                                           |     ^~~~~~~~~~~
```

---

```c++
In file included from /data/workspace/code/TXSQL/storage/temptable/src/indexed_cells.cc:31:
/data/workspace/code/TXSQL/include/my_hash_combine.h:84:13: error: variable or field ‘my_hash_combine’ declared void
   84 | inline void my_hash_combine(std::uint64_t &h, std::uint64_t k) {
      |             ^~~~~~~~~~~~~~~
/data/workspace/code/TXSQL/include/my_hash_combine.h:84:34: error: ‘uint64_t’ is not a member of ‘std’; did you mean ‘uint64_t’?
   84 | inline void my_hash_combine(std::uint64_t &h, std::uint64_t k) {
      |                                  ^~~~~~~~
In file included from /usr/include/stdint.h:37,
                 from /opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-redhat-linux/10/include/stdint.h:9,
                 from /data/workspace/code/TXSQL/include/my_hash_combine.h:64,
                 from /data/workspace/code/TXSQL/storage/temptable/src/indexed_cells.cc:31:
/usr/include/bits/stdint-uintn.h:27:20: note: ‘uint64_t’ declared here
   27 | typedef __uint64_t uint64_t;
      |                    ^~~~~~~~
In file included from /data/workspace/code/TXSQL/storage/temptable/src/indexed_cells.cc:31:
/data/workspace/code/TXSQL/include/my_hash_combine.h:84:44: error: ‘h’ was not declared in this scope
   84 | inline void my_hash_combine(std::uint64_t &h, std::uint64_t k) {
      |                                            ^
/data/workspace/code/TXSQL/include/my_hash_combine.h:84:52: error: ‘uint64_t’ is not a member of ‘std’; did you mean ‘uint64_t’?
   84 | inline void my_hash_combine(std::uint64_t &h, std::uint64_t k) {
      |                                                    ^~~~~~~~
In file included from /usr/include/stdint.h:37,
                 from /opt/rh/gcc-toolset-10/root/usr/lib/gcc/x86_64-redhat-linux/10/include/stdint.h:9,
                 from /data/workspace/code/TXSQL/include/my_hash_combine.h:64,
                 from /data/workspace/code/TXSQL/storage/temptable/src/indexed_cells.cc:31:
/usr/include/bits/stdint-uintn.h:27:20: note: ‘uint64_t’ declared here
   27 | typedef __uint64_t uint64_t;
      |                    ^~~~~~~~
```

---

```c++
/data/workspace/code/TXSQL/sql/rpl_binlog_sender.cc: In member function ‘void Binlog_sender::run()’:
/data/workspace/code/TXSQL/sql/rpl_binlog_sender.cc:362:42: error: ‘%s’ directive output may be truncated writing up to 511 bytes into a region of size between 427 and 938 [-Werror=format-truncation=]
  362 |                "the last byte read from '%s' at %lld.",
      |                                          ^~
/data/workspace/code/TXSQL/sql/rpl_binlog_sender.cc:360:16: note: using the range [-9223372036854775808, 9223372036854775807] for directive argument
  360 |                "%s; the first event '%s' at %lld, "
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  361 |                "the last event read from '%s' at %lld, "
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  362 |                "the last byte read from '%s' at %lld.",
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/data/workspace/code/TXSQL/sql/rpl_binlog_sender.cc:359:15: note: ‘snprintf’ output 94 or more bytes (assuming 1116) into a destination of size 1024
  359 |       snprintf(error_text, sizeof(error_text),
      |       ~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  360 |                "%s; the first event '%s' at %lld, "
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  361 |                "the last event read from '%s' at %lld, "
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  362 |                "the last byte read from '%s' at %lld.",
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  363 |                m_errmsg, m_start_file, m_start_pos, m_last_file, m_last_pos,
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  364 |                log_file, reader.position());
      |                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

---

```c++
/data/workspace/code/TXSQL/sql/udpsvr.cc: In member function ‘void CUdpServer::loopdealreq()’:
/data/workspace/code/TXSQL/sql/udpsvr.cc:146:20: error: ‘char* strncpy(char*, const char*, size_t)’ specified bound 24 equals destination size [-Werror=stringop-truncation]
  146 |             strncpy(fromaddr, inet_ntoa(from.sin_addr), 24);
      |             ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```