### PR TITLE
support SM3 HASH in user authentication

### DIFF
--- a/include/password.h
+++ b/include/password.h
@@ -35,8 +35,17 @@
 struct rand_struct *get_sql_rand();
 
 // extern "C" since it is an (undocumented) part of the libmysql ABI.
-extern "C" void my_make_scrambled_password(char *to, const char *password,
-                                           size_t pass_len);
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+void my_make_scrambled_password(char *to, const char *password,
+                                     size_t pass_len);
+
+#ifdef __cplusplus
+}
+#endif  /* __cplusplus */
+
 void my_make_scrambled_password_sha1(char *to, const char *password,
                                      size_t pass_len);
 

--- a/include/sm3.h
+++ b/include/sm3.h
@@ -1,0 +1,36 @@
+#ifdef __cplusplus
+
+
+extern "C" {
+#endif
+#ifndef SM3_INCLUDED
+#define SM3_INCLUDED
+
+#define SM3_HASH_SIZE 32
+#define SM3_SCRAMBLE_LENGTH  32
+#define SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH (SM3_SCRAMBLE_LENGTH*2+1)
+
+#ifndef UNUSED
+#define UNUSED(v) ((void)(v))
+#endif
+
+#include "my_inttypes.h"
+
+void txsql_make_scrambled_password(char *to, const unsigned char *password);
+
+void my_make_scrambled_password_sm3(char *to, const unsigned char *password, size_t pass_len);
+
+bool check_scramble_sm3(unsigned char *scramble_arg,
+	unsigned char *message,
+	unsigned char *hash_stage2);
+
+void get_salt_from_sm3_password(uint8 *hash_stage2, const char *password);
+
+void scramble_sm3(char *to, const unsigned char *message, const char *password);
+
+void sm3(unsigned char *input, int ilen, unsigned char output[32]);
+
+#endif
+#ifdef __cplusplus
+}
+#endif

--- a/libmysql/CMakeLists.txt
+++ b/libmysql/CMakeLists.txt
@@ -192,6 +192,7 @@ SET(CLIENT_SOURCES
   ../sql-common/bind_params.cc
   ../sql/auth/password.cc
   ../sql/auth/sha2_password_common.cc
+  ../sql/sm3.c
 )
 
 IF (WIN32 AND OPENSSL_APPLINK_C)

--- a/mysql-test/suite/tdsql/my.cnf
+++ b/mysql-test/suite/tdsql/my.cnf
@@ -19,3 +19,4 @@ SERVER_MYPORT_2= @mysqld.2.port
 SERVER_MYPORT_3= @mysqld.3.port
 SERVER_MYPORT_4= @mysqld.4.port
 SERVER_MYPORT_5= @mysqld.5.port
+MASTER_MYSOCK=@mysqld.1.socket

--- a/mysql-test/suite/tdsql/r/plugin_auth_sm3.result
+++ b/mysql-test/suite/tdsql/r/plugin_auth_sm3.result
@@ -1,0 +1,95 @@
+CREATE USER 'cup_dba' IDENTIFIED WITH 'txsql_sm3_password';
+ALTER USER 'cup_dba' IDENTIFIED BY 'secret';
+SELECT user, plugin FROM mysql.user where user = "cup_dba" ORDER BY user;
+user	plugin
+cup_dba	txsql_sm3_password
+SELECT USER(),CURRENT_USER();
+USER()	CURRENT_USER()
+cup_dba@localhost	cup_dba@%
+DROP USER 'cup_dba';
+CREATE USER 'cup_dba'@'localhost' IDENTIFIED WITH 'txsql_sm3_password';
+CREATE USER 'cup_dba2'@'localhost' IDENTIFIED WITH 'txsql_sm3_password';
+GRANT ALL ON *.* TO 'cup_dba'@'localhost';
+GRANT ALL ON *.* TO 'cup_dba2'@'localhost';
+ALTER USER 'cup_dba'@'localhost' IDENTIFIED BY 'secret2';
+ALTER USER 'cup_dba2'@'localhost' IDENTIFIED BY 'secret2';
+ERROR 28000: Access denied for user 'cup_dba'@'localhost' (using password: YES)
+SELECT USER(),CURRENT_USER();
+USER()	CURRENT_USER()
+cup_dba@localhost	cup_dba@localhost
+SHOW CREATE USER 'cup_dba'@'localhost';
+CREATE USER for cup_dba@localhost
+CREATE USER `cup_dba`@`localhost` IDENTIFIED WITH 'txsql_sm3_password' AS '<non-deterministic-password-hash>'
+Change user (should succeed)
+SELECT USER(),CURRENT_USER();
+USER()	CURRENT_USER()
+cup_dba2@localhost	cup_dba2@localhost
+**** Client default_auth=txsql_sm3_password and server default auth=native
+user()	current_user()
+cup_dba@localhost	cup_dba@localhost
+**** Client default_auth=native and server default auth=native
+user()	current_user()
+cup_dba@localhost	cup_dba@localhost
+# restart
+DROP USER 'cup_dba'@'localhost';
+DROP USER 'cup_dba2'@'localhost';
+CREATE USER 'cup_dba'@'localhost' IDENTIFIED WITH 'txsql_sm3_password';
+GRANT ALL ON *.* TO 'cup_dba'@'localhost';
+ALTER USER 'cup_dba'@'localhost' IDENTIFIED BY '';
+ERROR 28000: Access denied for user 'cup_dba'@'localhost' (using password: YES)
+SELECT USER(),CURRENT_USER();
+USER()	CURRENT_USER()
+cup_dba@localhost	cup_dba@localhost
+SHOW CREATE USER 'cup_dba'@'localhost';
+CREATE USER for cup_dba@localhost
+CREATE USER `cup_dba`@`localhost` IDENTIFIED WITH 'txsql_sm3_password' REQUIRE NONE PASSWORD EXPIRE DEFAULT ACCOUNT UNLOCK PASSWORD HISTORY DEFAULT PASSWORD REUSE INTERVAL DEFAULT PASSWORD REQUIRE CURRENT DEFAULT
+DROP USER 'cup_dba'@'localhost';
+CREATE USER 'cup_dba'@'33.33.33.33' IDENTIFIED WITH 'txsql_sm3_password';
+GRANT ALL ON *.* TO 'cup_dba'@'33.33.33.33';
+ALTER USER 'cup_dba'@'33.33.33.33' IDENTIFIED BY '';
+Connection should fail for localhost
+ERROR 28000: Access denied for user 'cup_dba'@'localhost' (using password: NO)
+DROP USER 'cup_dba'@'33.33.33.33';
+CREATE TABLE t1 (c1 VARCHAR(10) );
+INSERT INTO t1 VALUES ('secret');
+SELECT HEX(SM3_PASSWORD(c1)) FROM t1;
+HEX(SM3_PASSWORD(c1))
+2A42373937313744354637323741354339333238394533454442304531453444444331344532424539383242424330313535304534413246323544434634363938
+SELECT HEX(SM3(c1)) FROM t1;
+HEX(SM3(c1))
+32303633386166333335336661356264333961393333303063663532356563316538366538326635326239363565323036373134363163633864333537646261
+DROP TABLE t1;
+CREATE TABLE t1( c1 text, c2 varchar (2));
+INSERT INTO t1 VALUES (NULL,''),(NULL,''),(NULL,'');
+SELECT SM3_PASSWORD(c1), SM3_PASSWORD(c2) FROM t1;
+SM3_PASSWORD(c1)	SM3_PASSWORD(c2)
+	
+	
+	
+SELECT SM3(c1), SM3(c2) FROM t1;
+SM3(c1)	SM3(c2)
+NULL	1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b
+NULL	1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b
+NULL	1ab21d8355cfa17f8e61194831e81a8f22bec8c728fefb747ed035eb5082aa2b
+DROP TABLE t1;
+CREATE USER 'cup_dba' IDENTIFIED WITH 'txsql_sm3_password';
+ALTER USER 'cup_dba' IDENTIFIED BY 'secret';
+SELECT user, plugin FROM mysql.user where user = "cup_dba" ORDER BY user;
+user	plugin
+cup_dba	txsql_sm3_password
+SELECT USER(),CURRENT_USER();
+USER()	CURRENT_USER()
+cup_dba@localhost	cup_dba@%
+UPDATE mysql.user SET authentication_string= '$' WHERE user='cup_dba';
+FLUSH PRIVILEGES;
+SELECT user,authentication_string,plugin FROM mysql.user WHERE user='cup_dba';
+user	authentication_string	plugin
+cup_dba	$	txsql_sm3_password
+ERROR 28000: Access denied for user 'cup_dba'@'localhost' (using password: YES)
+UPDATE mysql.user SET authentication_string= '$5$asd' WHERE user='cup_dba';
+FLUSH PRIVILEGES;
+SELECT user,authentication_string,plugin FROM mysql.user WHERE user='cup_dba';
+user	authentication_string	plugin
+cup_dba	$5$asd	txsql_sm3_password
+ERROR 28000: Access denied for user 'cup_dba'@'localhost' (using password: YES)
+DROP USER cup_dba;

--- a/mysql-test/suite/tdsql/t/plugin_auth_sm3.test
+++ b/mysql-test/suite/tdsql/t/plugin_auth_sm3.test
@@ -1,0 +1,129 @@
+--source include/mysql_upgrade_preparation.inc
+
+# This test will intentionally generate errors in the server error log
+# when a broken password is inserted into the mysql.user table.
+# The below suppression is to clear those errors.
+--disable_query_log
+call mtr.add_suppression(".*Password salt for user.*");
+call mtr.add_suppression("Found invalid password for user:*");
+--enable_query_log
+
+CREATE USER 'cup_dba' IDENTIFIED WITH 'txsql_sm3_password';
+ALTER USER 'cup_dba' IDENTIFIED BY 'secret';
+SELECT user, plugin FROM mysql.user where user = "cup_dba" ORDER BY user;
+connect(con1,localhost,cup_dba,secret,,);
+connection con1;
+SELECT USER(),CURRENT_USER();
+connection default;
+disconnect con1;
+# Make sure authentication also works if client default_auth is changed and that
+# it possible to select a local public key fil using client options.
+DROP USER 'cup_dba';
+
+CREATE USER 'cup_dba'@'localhost' IDENTIFIED WITH 'txsql_sm3_password';
+CREATE USER 'cup_dba2'@'localhost' IDENTIFIED WITH 'txsql_sm3_password';
+GRANT ALL ON *.* TO 'cup_dba'@'localhost';
+GRANT ALL ON *.* TO 'cup_dba2'@'localhost';
+ALTER USER 'cup_dba'@'localhost' IDENTIFIED BY 'secret2';
+ALTER USER 'cup_dba2'@'localhost' IDENTIFIED BY 'secret2';
+--disable_query_log
+--error ER_ACCESS_DENIED_ERROR
+connect(con2,localhost,cup_dba,badpassword,,);
+--enable_query_log
+connect(con2,localhost,cup_dba,secret2,,);
+connection con2;
+SELECT USER(),CURRENT_USER();
+--replace_regex /AS .*$/AS '<non-deterministic-password-hash>'/
+SHOW CREATE USER 'cup_dba'@'localhost';
+
+--echo Change user (should succeed)
+change_user cup_dba2,secret2;
+SELECT USER(),CURRENT_USER();
+
+connection default;
+disconnect con2;
+--echo **** Client default_auth=txsql_sm3_password and server default auth=native
+--exec $MYSQL -ucup_dba -psecret2 --default_auth=txsql_sm3_password -e "select user(), current_user()"
+--echo **** Client default_auth=native and server default auth=native
+--exec $MYSQL -ucup_dba -psecret2 --default_auth=mysql_native_password -e "select user(), current_user()"
+# restart mysqld server to load user identified by sm3
+--source include/restart_mysqld.inc
+DROP USER 'cup_dba'@'localhost';
+DROP USER 'cup_dba2'@'localhost';
+
+CREATE USER 'cup_dba'@'localhost' IDENTIFIED WITH 'txsql_sm3_password';
+GRANT ALL ON *.* TO 'cup_dba'@'localhost';
+ALTER USER 'cup_dba'@'localhost' IDENTIFIED BY '';
+--disable_query_log
+--error ER_ACCESS_DENIED_ERROR
+connect(con3,localhost,cup_dba,wrongpass,,);
+--enable_query_log
+connect(con3,localhost,cup_dba,,,);
+connection con3;
+SELECT USER(),CURRENT_USER();
+--replace_regex /AS .*$/AS '<non-deterministic-password-hash>'/
+SHOW CREATE USER 'cup_dba'@'localhost';
+connection default;
+disconnect con3;
+DROP USER 'cup_dba'@'localhost';
+
+CREATE USER 'cup_dba'@'33.33.33.33' IDENTIFIED WITH 'txsql_sm3_password';
+GRANT ALL ON *.* TO 'cup_dba'@'33.33.33.33';
+ALTER USER 'cup_dba'@'33.33.33.33' IDENTIFIED BY '';
+--echo Connection should fail for localhost
+--replace_result $MASTER_MYSOCK MASTER_MYSOCK
+--disable_query_log
+--error ER_ACCESS_DENIED_ERROR
+connect(con4,127.0.0.1,cup_dba,,,);
+--enable_query_log
+DROP USER 'cup_dba'@'33.33.33.33';
+
+#
+# Test with non const arguments
+#
+CREATE TABLE t1 (c1 VARCHAR(10) );
+INSERT INTO t1 VALUES ('secret');
+SELECT HEX(SM3_PASSWORD(c1)) FROM t1;
+SELECT HEX(SM3(c1)) FROM t1;
+DROP TABLE t1;
+
+#
+# Test null argument
+# PASSWORD(NULL) should produce empty "" values.
+#
+CREATE TABLE t1( c1 text, c2 varchar (2));
+INSERT INTO t1 VALUES (NULL,''),(NULL,''),(NULL,'');
+SELECT SM3_PASSWORD(c1), SM3_PASSWORD(c2) FROM t1;
+SELECT SM3(c1), SM3(c2) FROM t1;
+DROP TABLE t1;
+
+#
+# test bad password formats
+#
+CREATE USER 'cup_dba' IDENTIFIED WITH 'txsql_sm3_password';
+ALTER USER 'cup_dba' IDENTIFIED BY 'secret';
+SELECT user, plugin FROM mysql.user where user = "cup_dba" ORDER BY user;
+--disable_query_log
+connect(con1,localhost,cup_dba,secret);
+--enable_query_log
+connection con1;
+SELECT USER(),CURRENT_USER();
+connection default;
+disconnect con1;
+UPDATE mysql.user SET authentication_string= '$' WHERE user='cup_dba';
+FLUSH PRIVILEGES;
+SELECT user,authentication_string,plugin FROM mysql.user WHERE user='cup_dba';
+--disable_query_log
+--error ER_ACCESS_DENIED_ERROR
+connect(con1,localhost,cup_dba,secret);
+--enable_query_log
+
+UPDATE mysql.user SET authentication_string= '$5$asd' WHERE user='cup_dba';
+FLUSH PRIVILEGES;
+SELECT user,authentication_string,plugin FROM mysql.user WHERE user='cup_dba';
+--disable_query_log
+--error ER_ACCESS_DENIED_ERROR
+connect(con1,localhost,cup_dba,secret);
+--enable_query_log
+DROP USER cup_dba;
+

--- a/sql-common/client.cc
+++ b/sql-common/client.cc
@@ -89,6 +89,7 @@
 #include "template_utils.h"
 #include "typelib.h"
 #include "violite.h"
+#include <sm3.h>
 
 #if !defined(_WIN32)
 #include "my_thread.h" /* because of signal()*/
@@ -4048,9 +4049,63 @@ static auth_plugin_t caching_sha2_password_client_plugin = {
     nullptr,
     caching_sha2_password_auth_client,
     caching_sha2_password_auth_client_nonblocking};
+
 #ifdef AUTHENTICATION_WIN
 extern "C" auth_plugin_t win_auth_client_plugin;
 #endif
+
+static int sm3_password_auth_client(MYSQL_PLUGIN_VIO *vio, MYSQL *mysql)
+{
+  int pkt_len = 0;
+  uchar *pkt;
+
+  DBUG_ENTER("sm3_password_auth_client");
+
+  pkt_len = vio->read_packet(vio, &pkt);
+
+  if (pkt_len < 0)
+    DBUG_RETURN(CR_ERROR);
+
+  if (pkt_len == 0) {
+    pkt = (uchar*)mysql->scramble;
+    pkt_len = SCRAMBLE_LENGTH + 1;
+  } else {
+    if (pkt_len != SCRAMBLE_LENGTH + 1)
+      DBUG_RETURN(CR_AUTH_HANDSHAKE);
+    memcpy(mysql->scramble, pkt, SCRAMBLE_LENGTH);
+    mysql->scramble[SCRAMBLE_LENGTH] = 0;
+  }
+
+  if (mysql->passwd[0]) {
+    char scrambled[SM3_SCRAMBLE_LENGTH + 1];
+    scramble_sm3(scrambled, (const unsigned char*)pkt, mysql->passwd);
+    if (vio->write_packet(vio, (uchar*)scrambled, SM3_SCRAMBLE_LENGTH))
+      DBUG_RETURN(CR_ERROR);
+  } else {
+    if (vio->write_packet(vio, 0, 0)) /* no password */
+      DBUG_RETURN(CR_ERROR);
+  }
+  DBUG_RETURN(CR_OK);
+}
+
+static auth_plugin_t sm3_password_client_plugin =
+{
+  MYSQL_CLIENT_AUTHENTICATION_PLUGIN,
+  MYSQL_CLIENT_AUTHENTICATION_PLUGIN_INTERFACE_VERSION,
+  "txsql_sm3_password",
+  "Weng Haixing",
+  "SM3 MySQL Authentication",
+  { 1, 0, 0 },
+  "GPL",
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  sm3_password_auth_client,
+  NULL
+};
+
 
 /*
   Test trace plugin can be used only in debug builds. In non-debug ones
@@ -4066,6 +4121,7 @@ extern auth_plugin_t test_trace_plugin;
 struct st_mysql_client_plugin *mysql_client_builtins[] = {
     (struct st_mysql_client_plugin *)&native_password_client_plugin,
     (struct st_mysql_client_plugin *)&clear_password_client_plugin,
+    (struct st_mysql_client_plugin *)&sm3_password_client_plugin,
     (struct st_mysql_client_plugin *)&sha256_password_client_plugin,
     (struct st_mysql_client_plugin *)&caching_sha2_password_client_plugin,
 #ifdef AUTHENTICATION_WIN
@@ -5630,6 +5686,7 @@ static mysql_state_machine_status authsm_begin_plugin_auth(
 
   if (check_plugin_enabled(mysql, ctx)) return STATE_MACHINE_FAILED;
 
+  DBUG_PRINT ("this", ("data_plugin=%s", ctx->data_plugin));
   DBUG_PRINT("info", ("using plugin %s", ctx->auth_plugin_name));
 
   mysql->net.last_errno = 0; /* just in case */

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -567,6 +567,7 @@ SET(SQL_SHARED_SOURCES
   sd_notify.cc
   sdi_utils.cc
   session_tracker.cc
+  sm3.c
   set_var.cc
   sp.cc
   sp_cache.cc

--- a/sql/auth/sql_auth_cache.h
+++ b/sql/auth/sql_auth_cache.h
@@ -56,6 +56,8 @@
 #include "sql/psi_memory_key.h"
 #include "sql/sql_connect.h"  // USER_RESOURCES
 #include "violite.h"          // SSL_type
+#include <mysql/plugin_auth.h>
+#include <sm3.h>
 
 /* Forward declarations */
 class Security_context;
@@ -224,7 +226,7 @@ class Acl_credential {
  public:
   Acl_credential() {
     m_auth_string = {"", 0};
-    memset(m_salt, 0, SCRAMBLE_LENGTH + 1);
+    memset(m_salt, 0, SM3_SCRAMBLE_LENGTH + 1);
     m_salt_len = 0;
   }
 
@@ -234,7 +236,7 @@ class Acl_credential {
     The salt variable is used as the password hash for
     native_password_authetication.
   */
-  uint8 m_salt[SCRAMBLE_LENGTH + 1];  // scrambled password in binary form
+  uint8 m_salt[SM3_SCRAMBLE_LENGTH + 1];   // scrambled password in binary form
   /**
     In the old protocol the salt_len indicated what type of autnetication
     protocol was used: 0 - no password, 4 - 3.20, 8 - 4.0,  20 - 4.1.1

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -995,15 +995,24 @@ inline const char *client_plugin_name(plugin_ref ref) {
   return ((st_mysql_auth *)(plugin_decl(ref)->info))->client_auth_plugin;
 }
 
+LEX_CSTRING sm3_password_plugin_name = {
+  STRING_WITH_LEN("txsql_sm3_password")
+};
+
 LEX_CSTRING validate_password_plugin_name = {
     STRING_WITH_LEN("validate_password")};
+
+LEX_CSTRING native_password_plugin_name = {
+    STRING_WITH_LEN("mysql_native_password")
+};
 
 LEX_CSTRING default_auth_plugin_name;
 
 const LEX_CSTRING Cached_authentication_plugins::cached_plugins_names[(
     uint)PLUGIN_LAST] = {{STRING_WITH_LEN("caching_sha2_password")},
                          {STRING_WITH_LEN("mysql_native_password")},
-                         {STRING_WITH_LEN("sha256_password")}};
+                         {STRING_WITH_LEN("sha256_password")},
+                         {STRING_WITH_LEN("txsql_sm3_password")}};
 
 /**
   Use known pointers for cached plugins to improve comparison time
@@ -1369,7 +1378,10 @@ int set_default_auth_plugin(char *plugin_name, size_t plugin_name_length) {
       !Cached_authentication_plugins::compare_plugin(
           PLUGIN_MYSQL_NATIVE_PASSWORD, default_auth_plugin_name) &&
       !Cached_authentication_plugins::compare_plugin(
-          PLUGIN_CACHING_SHA2_PASSWORD, default_auth_plugin_name))
+          PLUGIN_CACHING_SHA2_PASSWORD, default_auth_plugin_name) &&
+      !Cached_authentication_plugins::compare_plugin(
+          PLUGIN_SM3_PASSWORD,default_auth_plugin_name))
+
     return 1;
 
   if (!Cached_authentication_plugins::compare_plugin(
@@ -3291,7 +3303,18 @@ static int server_mpvio_read_packet(MYSQL_PLUGIN_VIO *param, uchar **buf) {
       useless. Furthermore, we have to send a "change plugin" request
       to the client.
     */
-    if (mpvio->write_packet(mpvio, nullptr, 0))
+    if(my_strcasecmp(system_charset_info, validate_password_plugin_name.str,
+                      client_auth_plugin_name) == 0 ||
+        my_strcasecmp(system_charset_info, native_password_plugin_name.str,
+                      client_auth_plugin_name) == 0)
+    {
+      if (send_plugin_request_packet(mpvio,
+                                 (uchar*) mpvio->cached_server_packet.pkt,
+                                 mpvio->cached_server_packet.pkt_len))
+        pkt_len= packet_error;
+      protocol->read_packet();
+      pkt_len= protocol->get_packet_length();
+    } else if (mpvio->write_packet(mpvio, nullptr, 0))
       pkt_len = packet_error;
     else {
       protocol->read_packet();
@@ -5943,6 +5966,162 @@ static bool do_auto_rsa_keys_generation() {
                             "--caching_sha2_password_auto_generate_rsa_keys"));
 }
 
+int generate_sm3_password(char *outbuf, unsigned int *outbuflen, const char *inbuf, unsigned int inbuflen)
+{
+  char *buffer;
+
+  DBUG_ENTER("generate_sm3_password");
+
+  if (my_validate_password_policy(inbuf, inbuflen))
+    return 1;
+  /* for empty passwords */
+  if (inbuflen == 0)
+  {
+    *outbuflen = 0;
+    DBUG_RETURN(0);
+  }
+  buffer = (char *)my_malloc(PSI_NOT_INSTRUMENTED, SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH + 1, MYF(0));
+  if (buffer == NULL)
+  DBUG_RETURN(1);
+  my_make_scrambled_password_sm3(buffer, (const unsigned char *)inbuf, inbuflen);
+  /*
+  if buffer specified by server is smaller than the buffer given
+  by plugin then return error
+  */
+  if (*outbuflen < strlen(buffer))
+  {
+    my_free(buffer);
+    DBUG_RETURN(1);
+  }
+  *outbuflen = SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH;
+  memcpy(outbuf, buffer, *outbuflen);
+  my_free(buffer);
+  DBUG_RETURN(0);
+}
+
+int validate_sm3_password_hash(char* const inbuf, unsigned int buflen)
+{
+  DBUG_ENTER("validate_sm3_password_hash");
+
+  if ((buflen &&
+      buflen == SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH && inbuf[0] == '*') ||
+      buflen == 0)
+    DBUG_RETURN(0);
+  DBUG_RETURN(1);
+}
+
+int set_sm3_salt(const char* password, unsigned int password_len,
+	unsigned char* salt, unsigned char *salt_len)
+{
+  DBUG_ENTER("set_sm3_salt");
+
+  if (password_len == 0)
+    *salt_len = 0;
+  else
+  {
+    if (password_len == SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH)
+    {
+      get_salt_from_sm3_password(salt, password);
+      *salt_len = SM3_SCRAMBLE_LENGTH;
+    }
+  }
+  DBUG_RETURN(0);
+}
+
+int sm3_password_authenticate(MYSQL_PLUGIN_VIO *vio, MYSQL_SERVER_AUTH_INFO *info)
+{
+  uchar *pkt;
+  int pkt_len;
+
+  unsigned char scramble[SCRAMBLE_LENGTH + 1];
+
+  DBUG_ENTER("sm3_password_authenticate");
+
+  generate_user_salt((char *)scramble, SCRAMBLE_LENGTH + 1);
+
+  DBUG_PRINT("this", ("scramble=%s",scramble));
+
+  /* send it to the client */
+  if (vio->write_packet(vio, (const unsigned char *)scramble, SCRAMBLE_LENGTH + 1))
+    DBUG_RETURN(CR_AUTH_HANDSHAKE);
+
+  /* read the reply with the encrypted password */
+  if ((pkt_len = vio->read_packet(vio, &pkt)) < 0)
+    DBUG_RETURN(CR_AUTH_HANDSHAKE);
+
+  /*
+  if (mysql_native_password_proxy_users)
+  {
+    *info->authenticated_as = PROXY_FLAG;
+    DBUG_PRINT("info", ("mysql_native_authentication_proxy_users is enabled, setting authenticated_as to NULL"));
+  }
+  */
+  if (pkt_len == 0) /* no password */
+    DBUG_RETURN(info->auth_string_length != 0 ? CR_AUTH_USER_CREDENTIALS : CR_OK);
+
+  info->password_used = PASSWORD_USED_YES;
+
+  DBUG_PRINT("this", ("pkt_len = %d", pkt_len));
+  DBUG_PRINT("info", ("auth_string = %s, auth_string_length = %ld", info->auth_string, info->auth_string_length));
+
+  if (pkt_len == SM3_SCRAMBLE_LENGTH)
+  {
+    unsigned char salt[SM3_SCRAMBLE_LENGTH + 1];
+    unsigned char salt_len = SM3_SCRAMBLE_LENGTH;
+
+    if (info->auth_string_length == 0)
+      DBUG_RETURN(CR_AUTH_USER_CREDENTIALS);
+
+    //DBUG_RETURN(check_scramble_sm3(pkt, scramble, (unsigned char *)info->auth_string) ? CR_AUTH_USER_CREDENTIALS : CR_OK);
+
+    set_sm3_salt(info->auth_string, info->auth_string_length, salt, &salt_len);
+
+    DBUG_RETURN(check_scramble_sm3(pkt, scramble, salt) ? CR_AUTH_USER_CREDENTIALS : CR_OK);
+  }
+  DBUG_RETURN(CR_AUTH_HANDSHAKE);
+}
+
+/**
+  Compare a clear text password with a stored hash for
+  the sm3 password plugin
+
+  If the password is non-empty it calculates a hash from
+  the cleartext and compares it with the supplied hash.
+
+  if the password is empty checks if the hash is empty too.
+
+  @arg hash              pointer to the hashed data
+  @arg hash_length       length of the hashed data
+  @arg cleartext         pointer to the clear text password
+  @arg cleartext_length  length of the cleat text password
+  @arg[out] is_error     non-zero in case of error extracting the salt
+  @retval 0              the hash was created with that password
+  @retval non-zero       the hash was created with a different password
+*/
+static int compare_sm3_password_with_hash(const char *hash,
+                                             unsigned long hash_length,
+                                             const char *cleartext,
+                                             unsigned long cleartext_length,
+                                             int *is_error) {
+  DBUG_TRACE;
+
+  char buffer[SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH + 1];
+
+  /** empty password results in an empty hash */
+  if (!hash_length && !cleartext_length) return 0;
+
+  assert(hash_length <= SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH);
+
+  /* calculate the hash from the clear text */
+  my_make_scrambled_password_sm3(buffer, (const unsigned char*)cleartext, cleartext_length);
+
+  *is_error = 0;
+  int result = memcmp(hash, buffer, SM3_SCRAMBLED_PASSWORD_CHAR_LENGTH);
+
+  return result;
+}
+
+
 bool MPVIO_EXT::can_authenticate() {
   return (acl_user && acl_user->can_authenticate);
 }
@@ -5968,6 +6147,18 @@ static struct st_mysql_auth sha256_password_handler = {
     set_sha256_salt,
     AUTH_FLAG_USES_INTERNAL_STORAGE,
     compare_sha256_password_with_hash,
+};
+
+struct st_mysql_auth sm3_auth_plugin_handler =
+{
+  MYSQL_AUTHENTICATION_INTERFACE_VERSION,
+  "txsql_sm3_password",					    /* requires test_plugin client's plugin */
+  sm3_password_authenticate,
+  generate_sm3_password,
+  validate_sm3_password_hash,
+  set_sm3_salt,
+  AUTH_FLAG_USES_INTERNAL_STORAGE,
+  compare_sm3_password_with_hash
 };
 
 mysql_declare_plugin(mysql_password){
@@ -6003,4 +6194,23 @@ mysql_declare_plugin(mysql_password){
         sha256_password_sysvars,          /* system variables */
         nullptr,                          /* config options   */
         0                                 /* flags            */
-    } mysql_declare_plugin_end;
+    }
+,
+{
+  MYSQL_AUTHENTICATION_PLUGIN,
+  &sm3_auth_plugin_handler,        /* type-specific descriptor */
+  Cached_authentication_plugins::get_plugin_name(
+            PLUGIN_SM3_PASSWORD),     /* plugin name */
+  "Haixing Weng",                    /* author */
+  "SM3 password authentication",   /* description */
+  PLUGIN_LICENSE_GPL,              /* license type */
+  NULL,                            /* init function */
+  NULL,                            /* deinit function */
+  NULL,                            /* check uninstall*/
+  0x0100,                          /* version = 1.0 */
+  NULL,                            /* status variables */
+  NULL,                            /* system variables */
+  NULL,                            /* no reserved information */
+  0                                /* no flags */
+}   
+     mysql_declare_plugin_end;

--- a/sql/auth/sql_authentication.h
+++ b/sql/auth/sql_authentication.h
@@ -159,6 +159,7 @@ typedef enum {
   PLUGIN_CACHING_SHA2_PASSWORD = 0,
   PLUGIN_MYSQL_NATIVE_PASSWORD,
   PLUGIN_SHA256_PASSWORD,
+  PLUGIN_SM3_PASSWORD,
   /* Add new plugin before this */
   PLUGIN_LAST
 } cached_plugins_enum;

--- a/sql/item_create.cc
+++ b/sql/item_create.cc
@@ -1545,6 +1545,8 @@ static const std::pair<const char *, Create_func *> func_array[] = {
     {"SIGN", SQL_FN(Item_func_sign, 1)},
     {"SIN", SQL_FN(Item_func_sin, 1)},
     {"SLEEP", SQL_FN(Item_func_sleep, 1)},
+    {"SM3", SQL_FN(Item_func_sm3, 1)},
+    {"SM3_PASSWORD", SQL_FN(Item_func_sm3_password, 1)},
     {"SOUNDEX", SQL_FN(Item_func_soundex, 1)},
     {"SOURCE_POS_WAIT", SQL_FN_V(Item_source_pos_wait, 2, 4)},
     {"SPACE", SQL_FN(Item_func_space, 1)},

--- a/sql/item_strfunc.cc
+++ b/sql/item_strfunc.cc
@@ -123,6 +123,7 @@
 #include "typelib.h"
 #include "unhex.h"
 #include "protocol.h"
+#include <sm3.h>
 
 extern uint *my_aes_opmode_key_sizes;
 
@@ -260,6 +261,73 @@ bool Item_func_sha::resolve_type(THD *thd) {
   args[0]->collation.set(cs, DERIVATION_COERCIBLE);
   // size of hex representation of hash
   set_data_type_string(SHA1_HASH_SIZE * 2, default_charset());
+  return false;
+}
+
+String *Item_func_sm3::val_str_ascii(String *str) {
+  assert(fixed == 1);
+  String * sptr = args[0]->val_str(str);
+  str->set_charset(&my_charset_bin);
+  if (sptr)  /* If we got value different from NULL */
+  {
+    /* Temporary buffer to store 160bit digest */
+    uint8 digest[SM3_HASH_SIZE];
+    sm3((unsigned char *)sptr->ptr(), sptr->length(), digest);
+    /* Ensure that memory is free */
+    if (!(str->alloc(SM3_HASH_SIZE * 2)))
+    {
+      array_to_hex((char *)str->ptr(), digest, SM3_HASH_SIZE);
+      str->length((uint)SM3_HASH_SIZE * 2);
+      null_value = 0;
+      return str;
+    }
+  }
+  null_value = 1;
+  return 0;
+}
+
+bool Item_func_sm3::resolve_type(THD *thd) {
+  if (param_type_is_default(thd, 0, 1)) return true;
+  CHARSET_INFO *cs = get_checksum_charset(args[0]->collation.collation->csname);
+  args[0]->collation.set(cs, DERIVATION_COERCIBLE);
+  // size of hex representation of hash
+  set_data_type_string(SM3_HASH_SIZE * 2 + 1, default_charset());
+  return false;
+}
+
+String *Item_func_sm3_password::val_str_ascii(String *str) {
+  assert(fixed == 1);
+  String * sptr = args[0]->val_str(str);
+  str->set_charset(&my_charset_bin);
+  if (sptr)  /* If we got value different from NULL */
+  {
+    if (sptr->length() == 0)
+    {
+      str = make_empty_result();
+      return str;
+    }
+    if (!(str->alloc(SM3_HASH_SIZE * 2 + 1)))
+    {
+      my_make_scrambled_password_sm3((char *)str->ptr(), (const unsigned char *)sptr->ptr(), sptr->length());
+      str->length((uint)SM3_HASH_SIZE * 2 + 1);
+      null_value = 0;
+      return str;
+    }
+  }
+  else {
+    str = make_empty_result();
+    return str;
+  }
+  null_value = 1;
+  return 0;
+}
+
+bool Item_func_sm3_password::resolve_type(THD *thd) {
+  if (param_type_is_default(thd, 0, 1)) return true;
+  CHARSET_INFO *cs = get_checksum_charset(args[0]->collation.collation->csname);
+  args[0]->collation.set(cs, DERIVATION_COERCIBLE);
+  // size of hex representation of hash
+  set_data_type_string(SM3_HASH_SIZE * 2, default_charset());
   return false;
 }
 

--- a/sql/item_strfunc.h
+++ b/sql/item_strfunc.h
@@ -208,6 +208,23 @@ class Item_func_sha2 : public Item_str_ascii_func {
   const char *func_name() const override { return "sha2"; }
 };
 
+class Item_func_sm3 : public Item_str_ascii_func {
+ public:
+  Item_func_sm3(const POS &pos, Item *a) : Item_str_ascii_func(pos, a) {}
+  String *val_str_ascii(String *) override;
+  bool resolve_type(THD *thd) override;
+  const char *func_name() const override { return "sm3"; }
+};
+
+class Item_func_sm3_password : public Item_str_ascii_func {
+ public:
+  Item_func_sm3_password(const POS &pos, Item *a)
+      : Item_str_ascii_func(pos, a) {}
+  String *val_str_ascii(String *) override;
+  bool resolve_type(THD *thd) override;
+  const char *func_name() const override { return "sm3_password"; }
+};
+
 class Item_func_to_base64 final : public Item_str_ascii_func {
   String tmp_value;
 

--- a/sql/sm3.c
+++ b/sql/sm3.c
@@ -1,0 +1,260 @@
+/*===================================================================
+*
+*
+*
+* Copyright (C) 2010, 2013 wenghaixing.
+*
+* Created on 2016-08-17 by wenghaixing (wenghaixing@unionpay.com)
+*
+* -------------------------------------------------------------------
+*
+* Description
+* this is txsql.gm sm3 encrypt source code
+* see that www.oscca.gov.cn/News/201012/News_1199.htm
+* download the sm3 pdf.
+* -------------------------------------------------------------------
+*
+* Change Log
+*
+*====================================================================*/
+
+#include "password.h"
+#include "mysql.h"
+#include "sm3.h"
+#include "my_inttypes.h"
+#include <string.h>
+#include <openssl/evp.h>
+#include <openssl/err.h>
+#include <openssl/hmac.h>
+
+
+/** =======================================================
+*  Then we will define the func used in mysql auth
+*  =======================================================*/
+
+#define SM3_PVERSION41_CHAR '*'
+
+/** =======================================================
+*  We use openssl's SM3 function
+*  =======================================================*/
+void sm3(unsigned char *input, int ilen,
+	unsigned char output[32])
+{
+  EVP_MD_CTX *mdctx = NULL;
+  const EVP_MD *md;
+  unsigned int md_len, i;
+  OpenSSL_add_all_digests();
+  
+  md = EVP_get_digestbyname("SM3");
+  if (!md) {
+    /* error , return */
+    return;
+  }
+
+  mdctx = EVP_MD_CTX_create();
+  if (!mdctx) {
+    /* error , return */
+    return;
+  }
+
+  EVP_MD_CTX_init(mdctx);
+  EVP_DigestInit_ex(mdctx, md, NULL);
+  EVP_DigestUpdate(mdctx, input, ilen);
+  EVP_DigestFinal_ex(mdctx, output, &md_len);
+
+  /* release context */
+  EVP_MD_CTX_destroy(mdctx);
+
+  return;
+}
+
+
+/** =======================================================
+*  output = HMAC-SM#( hmac key, input buffer )
+*  =======================================================*/
+void sm3_hmac(unsigned char *key, int keylen,
+	unsigned char *input, int ilen,
+	unsigned char output[32])
+{
+  EVP_MD_CTX *mdctx = NULL;
+  const EVP_MD *md;
+  unsigned int md_len;
+  OpenSSL_add_all_digests();
+  
+  md = EVP_get_digestbyname("SM3");
+  if (!md) {
+    /* error , return */
+    return;
+  }
+
+  mdctx = EVP_MD_CTX_create();
+  if (!mdctx) {
+    /* error , return */
+    return;
+  }
+
+  HMAC(md, (const unsigned char*)(key), keylen,
+       (const unsigned char*)(input), ilen,
+       output, &md_len);
+  
+  return;
+}
+
+/** =======================================================
+*  Simple Crypt Function
+*  =======================================================*/
+
+static void my_crypt_sm3(char *to, const uchar *s1, const uchar *s2, uint len)
+{
+  const uint8 *s1_end = s1 + len;
+  while (s1 < s1_end)
+    *to++ = *s1++ ^ *s2++;
+}
+
+/** =======================================================
+*  Convert into a lower case char
+*  =======================================================*/
+static inline uint8 sm3_char_val(uint8 X)
+{
+  return (uint)(X >= '0' && X <= '9' ? X - '0' :
+         X >= 'A' && X <= 'Z' ? X - 'A' + 10 : X - 'a' + 10);
+}
+
+/** =======================================================
+*  HEX2OCTET
+*  =======================================================*/
+
+static void sm3_hex2octet(uint8 *to, const char *str, uint len)
+{
+  const char *str_end = str + len;
+  while (str < str_end) {
+    register char tmp = sm3_char_val(*str++);
+    *to++ = (tmp << 4) | sm3_char_val(*str++);
+  }
+}
+
+static const char sm3_dig_vec_upper[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+static const char sm3_dig_vec_lower[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+
+/** =======================================================
+*  OCTET2HEX
+*  =======================================================*/
+static char *sm3_octet2hex(char *to, const char *str, uint len)
+{
+  UNUSED(sm3_dig_vec_lower);
+
+  const char *str_end = str + len;
+  for (; str != str_end; ++str)
+  {
+    *to++ = sm3_dig_vec_upper[((uchar)*str) >> 4];
+    *to++ = sm3_dig_vec_upper[((uchar)*str) & 0x0F];
+  }
+  *to = '\0';
+  return to;
+}
+
+/** =======================================================
+*  Caculate 2 stage sm3 hash
+*  =======================================================*/
+static
+void compute_two_stage_sm3_hash(const unsigned char *password,
+size_t pass_len,
+unsigned char *hash_stage1,
+unsigned char *hash_stage2)
+{
+  /* Stage 1: hash password */
+  sm3((unsigned char *)password, pass_len, hash_stage1);
+
+
+  /* Stage 2 : hash first stage's output. */
+  sm3(hash_stage1, SM3_HASH_SIZE, hash_stage2);
+}
+
+/** =======================================================
+*  Use scramble to encrypt password with sm3
+*  We think it's better to use hmac with scramble string
+*  =======================================================*/
+void scramble_sm3_from_clear_text(char *to, const unsigned char *message, const char *password)
+{
+  unsigned char hash_stage1[SM3_HASH_SIZE];
+  unsigned char hash_stage2[SM3_HASH_SIZE];
+
+  /* Two stage SM3 hash of the password. */
+  compute_two_stage_sm3_hash((unsigned char *)password, strlen(password),
+  hash_stage1, hash_stage2);
+
+  sm3_hmac((unsigned char*)message, SCRAMBLE_LENGTH, hash_stage2, SM3_HASH_SIZE, (unsigned char *)to);
+
+  my_crypt_sm3(to, (const uchar *)to, hash_stage1, SM3_SCRAMBLE_LENGTH);
+}
+
+void scramble_sm3(char *to, const unsigned char *message, const char *password)
+{
+  scramble_sm3_from_clear_text(to, message, password);
+}
+
+bool check_scramble_sm3(unsigned char *scramble_arg,
+	unsigned char *message,
+	unsigned char *hash_stage2)
+{
+  unsigned char buf[SM3_HASH_SIZE];
+  unsigned char hash_stage2_reassured[SM3_HASH_SIZE];
+  /* create key to encrypt scramble */
+
+  memset(buf, 0x00, SM3_HASH_SIZE);
+
+  sm3_hmac(message, SCRAMBLE_LENGTH, hash_stage2, SM3_HASH_SIZE, buf);
+
+  /* encrypt scramble */
+  my_crypt_sm3((char *)buf, buf, scramble_arg, SM3_SCRAMBLE_LENGTH);
+
+  /* now buf supposedly contains hash_stage1: so we can get hash_stage2 */
+  sm3(buf, SM3_HASH_SIZE, hash_stage2_reassured);
+
+  return (memcmp(hash_stage2, hash_stage2_reassured, SM3_HASH_SIZE)) ? true : false;
+}
+
+/*
+Convert scrambled password from asciiz hex string to binary form.
+
+SYNOPSIS
+get_salt_from_password()
+res       OUT buf to hold password. Must be at least SM3_HASH_SIZE
+bytes long.
+password  IN  4.1.1 version value of user.password
+*/
+
+void get_salt_from_sm3_password(uint8 *hash_stage2, const char *password)
+{
+  sm3_hex2octet(hash_stage2, password + 1 /* skip '*' */, SM3_HASH_SIZE * 2);
+}
+
+/*
+Convert scrambled password from binary form to asciiz hex string.
+SYNOPSIS
+make_password_from_salt()
+to    OUT store resulting string here, 2*SHA1_HASH_SIZE+2 bytes
+salt  IN  password in salt format
+*/
+
+void make_sm3_password_from_salt(char *to, const uint8 *hash_stage2)
+{
+  *to++ = SM3_PVERSION41_CHAR;
+  sm3_octet2hex(to, (const char*)hash_stage2, SM3_HASH_SIZE);
+}
+
+
+void my_make_scrambled_password_sm3(char *to, const unsigned char *password, size_t pass_len)
+{
+  unsigned char hash_stage2[SM3_HASH_SIZE];
+  compute_two_stage_sm3_hash(password, pass_len,
+                            (unsigned char*)to, hash_stage2);
+  *to++ = SM3_PVERSION41_CHAR;
+  sm3_octet2hex(to, (const char*)hash_stage2, SM3_HASH_SIZE);
+}
+
+
+void txsql_make_scrambled_password(char *to, const unsigned char *password)
+{
+  my_make_scrambled_password_sm3(to, password, strlen((const char *)password));
+}


### PR DESCRIPTION
Description:
========
Introduce a new feature in the database user login authentication phase to support using the SM3 hash algorithm, replacing existing algorithms such as SHA1 and SHA2, thereby enhancing security.

Main things:
========
1. When creating a user, specify the plugin and declare the use of the SM3 hash algorithm during login authentication. Below is an example: CREATE USER <username>[@<hostname>] IDENTIFIED WITH 'txsql_sm3_password' BY '<Your Password>';
2. Two functions are provided: SM3(<data>) to generate digest values. SM3_PASSWORD(<data>) to generate password digests.
3. You need using TXSQL's client/library to connect with sm3 hash user's 

By Weng Haixing <wenghaixing@unionpay.com>