### PR TITLE
support disable DDL operation

### DIFF
--- a/share/messages_to_clients.txt
+++ b/share/messages_to_clients.txt
@@ -10085,6 +10085,9 @@ ER_RECYCLE_BIN_CAN_NOT_TRUNCATE_TABLE_WITH_TRIGGERS
 # End of parallel execution specific messages to be sent to client
 #
 
+ER_DDL_DISABLED
+  eng "DDL statement are disabled by txsql_disable_ddl variable."
+
 ################################################################################
 # DO NOT add messages for the error-log to this file;
 # they go in messages_to_error_log.txt in the same

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1356,6 +1356,8 @@ bool sp_automatic_privileges = true;
 int32_t opt_regexp_time_limit;
 int32_t opt_regexp_stack_limit;
 
+bool txsql_disable_ddl = false;
+
 /** True, if restarted from a cloned database. This information
 is needed by GR to set some configurations right after clone. */
 bool clone_startup = false;

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -444,6 +444,8 @@ extern ulonglong global_conn_mem_limit;
 extern ulonglong global_conn_mem_counter;
 extern char *sql_filter_command;
 extern ulong cdb_node_role;
+extern bool txsql_disable_ddl;
+
 // length limited by ROLENAME_CHAR_LENGTH
 enum enum_cdb_role {
   CDB_ROLE_UNKNOWN = 0,

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -4052,6 +4052,42 @@ int mysql_execute_command(THD *thd, bool first_level) {
     until we have the MDL, and LOCK TABLE could massively delay this.
   */
 
+  if (txsql_disable_ddl)
+  {
+    switch(lex->sql_command) {
+    case SQLCOM_CREATE_DB:
+    case SQLCOM_ALTER_DB:
+    case SQLCOM_DROP_DB:
+    case SQLCOM_CREATE_TABLE:
+    case SQLCOM_ALTER_TABLE:
+    case SQLCOM_DROP_TABLE:
+    case SQLCOM_TRUNCATE:
+    case SQLCOM_RENAME_TABLE:
+    case SQLCOM_OPTIMIZE:
+    case SQLCOM_ANALYZE:
+    case SQLCOM_CHECK:
+    case SQLCOM_REPAIR:
+    case SQLCOM_CREATE_INDEX:
+    case SQLCOM_DROP_INDEX:
+    case SQLCOM_CREATE_VIEW:
+    case SQLCOM_DROP_VIEW:
+    case SQLCOM_CREATE_PROCEDURE:
+    case SQLCOM_ALTER_PROCEDURE:
+    case SQLCOM_DROP_PROCEDURE:
+    case SQLCOM_CREATE_FUNCTION:
+    case SQLCOM_DROP_FUNCTION:
+    case SQLCOM_CREATE_TRIGGER:
+    case SQLCOM_DROP_TRIGGER:
+    case SQLCOM_CREATE_EVENT:
+    case SQLCOM_ALTER_EVENT:
+    case SQLCOM_DROP_EVENT:
+      my_error(ER_DDL_DISABLED, MYF(0));
+      goto error;
+    default:
+      break;
+    }
+  }
+
   switch (lex->sql_command) {
     case SQLCOM_PREPARE: {
       mysql_sql_stmt_prepare(thd);

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -9159,4 +9159,8 @@ static Sys_var_bool Sys_tdsql_current_session_sqlasyn(
     SESSION_ONLY(txsql_disable_sqlasyn), CMD_LINE(OPT_ARG), DEFAULT(false),
     NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL), ON_UPDATE(NULL));
 
+static Sys_var_bool Sys_txsql_disable_ddl(
+       "txsql_disable_ddl",
+       "Disable DDL statement where ON",
+       GLOBAL_VAR(txsql_disable_ddl), CMD_LINE(OPT_ARG), DEFAULT(false));    
 /* Changes from txsql end. */


### PR DESCRIPTION
Description:
========
Introduce a new feature than user can disable or enable DDL operation, controled by a new globle variable 'txsql_disable_ddl', enhancing security.

Main things:
========
1. The new variable 'txsql_disable_dll' is globle, you can't set it in session.
2. When 'txsql_disable_ddl' is set ON, means all DDL operations are prohibited, like CREATE-TABLE/ALTER-TABLE command. IF you want to restore, please set it OFF.

By Pang Tianze <pangtianze@unionpay.com>