### PR TITLE
support monitor sensitive operation

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1293,6 +1293,8 @@ bool opt_log_replica_updates = false;
 char *opt_replica_skip_errors;
 bool opt_replica_allow_batching = true;
 
+bool txsql_audit_alter_table_enable= false;
+bool txsql_audit_set_option_enable= false;
 /**
   compatibility option:
     - index usage hints (USE INDEX without a FOR clause) behave as in 5.0

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -343,6 +343,8 @@ extern MYSQL_PLUGIN_IMPORT ulong max_connections;
 extern ulong max_digest_length;
 extern ulong max_connect_errors, connect_timeout;
 extern bool opt_replica_allow_batching;
+extern bool txsql_audit_alter_table_enable;
+extern bool txsql_audit_set_option_enable;
 extern ulong slave_trans_retries;
 extern uint replica_net_timeout;
 extern ulong opt_mts_replica_parallel_workers;

--- a/sql/set_var.cc
+++ b/sql/set_var.cc
@@ -351,6 +351,35 @@ bool sys_var::update(THD *thd, set_var *var) {
     */
     AutoWLock lock1(&PLock_global_system_variables);
     AutoWLock lock2(guard);
+    if(txsql_audit_set_option_enable)
+    {
+      /*
+        Hook the 'SET GLOBAL OPTION' command and warn the info out.
+      */
+      const char *user = thd->security_context()->user().str;
+      const char *ip = thd->security_context()->ip().str;
+      const char *key = name.str;
+      char str_val_buf[MAX_INTERVAL_VALUE_LENGTH+1];
+      String str_val(str_val_buf, sizeof(str_val_buf),
+                           system_charset_info);
+
+      String *option_val = var->value->val_str(&str_val);
+      if (!option_val)
+      {
+        //do nothing
+      }
+      else if (0 == option_val->length())
+      {
+       sql_print_information(
+       "[SECURITY WARNING][CONFIG] User '%s'@'%s' modified: SET GLOBAL %s=%d",
+       user, ip, key, var->value->val_int());
+      }else
+      {
+        sql_print_information(
+        "[SECURITY WARNING][CONFIG] User '%s'@'%s' modified: SET GLOBAL %s=%s",
+        user, ip, key, option_val->c_ptr());
+      }
+    }
     return global_update(thd, var) ||
            (on_update && on_update(this, thd, OPT_GLOBAL));
   } else {

--- a/sql/sql_parse.cc
+++ b/sql/sql_parse.cc
@@ -5395,6 +5395,24 @@ int mysql_execute_command(THD *thd, bool first_level) {
     case SQLCOM_REPAIR:
     case SQLCOM_TRUNCATE:
     case SQLCOM_ALTER_TABLE:
+    {
+      if(txsql_audit_alter_table_enable)
+      {
+        if(lex->sql_command == SQLCOM_ALTER_TABLE)
+        {
+          /*
+            Hook the 'ALTER TABLE' command and warn the info out.
+          */
+          const char *user = thd->security_context()->user().str;
+          const char *ip = thd->security_context()->ip().str;
+          const char *query_str = thd->query().str;
+          sql_print_information(
+            "[SECURITY WARNING][DDL] User '%s'@'%s' execute: %s",
+            user, ip, query_str);
+        }
+      }
+      [[fallthrough]];  
+    }
     case SQLCOM_HA_OPEN:
     case SQLCOM_HA_READ:
     case SQLCOM_HA_CLOSE:

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -9142,6 +9142,19 @@ bool have_tdsql = true;
 bool have_tdsql = false;
 #endif
 
+static Sys_var_bool Sys_txsql_audit_alter_table_enable(
+       "txsql_audit_alter_table_enable",
+       "Monitor alter table command and warn the info out.",
+       GLOBAL_VAR(txsql_audit_alter_table_enable), CMD_LINE(OPT_ARG),
+       DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(NULL), ON_UPDATE(NULL));
+static Sys_var_bool Sys_txsql_audit_set_option_enable(
+       "txsql_audit_set_option_enable",
+       "Monitor set option command and warn the info out.",
+       GLOBAL_VAR(txsql_audit_set_option_enable), CMD_LINE(OPT_ARG),
+       DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+       ON_CHECK(NULL), ON_UPDATE(NULL));
+
 static Sys_var_bool Sys_have_tdsql(
     "have_tdsql", "Whether the server was compiled with TDSQL support.",
     READ_ONLY GLOBAL_VAR(have_tdsql), NO_CMD_LINE, DEFAULT(have_tdsql),


### PR DESCRIPTION
Description:
========
Introduce a new feature that monitoring sensitive database operations, including modify table schemas, variables, or configuration items. Related database operations will be recorded in the error log.

Main things:
========
1. Two new global variables, "txsql_audit_alter_table_enable" and "txsql_audit_set_option_enable", decide whether monitor sensitive operations or not.
2. When txsql_audit_alter_table_enable is ON, means monitoring "modify table scheams" operation; and when txsql_audit_set_option_enable is ON, means monitoring "modify variables, config" oeration.
3. The monitor log record in error log file is on INFO level, you need set log_error_verbosity=3 to check them.

By Pang Tianze <pangtianze@unionpay.com>