### PR TITLE
Bug#36765223: performance deterioration caused by incorrect cpu usage…

### DIFF
--- a/storage/innobase/srv/srv0srv.cc
+++ b/storage/innobase/srv/srv0srv.cc
@@ -2337,13 +2337,7 @@ static void srv_update_cpu_usage() {
     return;
   }
 
-  int n_cpu = 0;
-  constexpr int MAX_CPU_N = 128;
-  for (int i = 0; i < MAX_CPU_N; ++i) {
-    if (CPU_ISSET(i, &cs)) {
-      ++n_cpu;
-    }
-  }
+  const int n_cpu = CPU_COUNT(&cs);
 
   srv_cpu_usage.n_cpu = n_cpu;
   MONITOR_SET(MONITOR_CPU_N, int64_t(n_cpu));


### PR DESCRIPTION
… statistics

srv_update_cpu_usage() (Linux path) doesn't look cpu affinity bits over 128. It causes ignoring cpu counts for processor id over 128. This fix changes to look all available cpu affinity bits by sched_getaffinity()

FYI, Windows path is still limited to 64, because GetProcessAffinityMask() API can treat 64 bit only.

Change-Id: I904938b19c5ddc68c2e9150eb42669b6b3e88a80