### PR TITLE
[optimization] flush redolog and binlog parallelly

### DIFF
--- a/include/my_thread_local.h
+++ b/include/my_thread_local.h
@@ -63,6 +63,10 @@ my_thread_id my_thread_var_id();
 
 void set_my_thread_var_id(my_thread_id id);
 
+CODE_STATE *code_state(void);
+void *get_cs_stack(CODE_STATE *cs);
+void set_cs_stack(CODE_STATE *cs_mod, void *stack);
+
 /* Changes from txsql start. */
 struct st_my_thread_var *mysys_thread_var();
 

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -978,6 +978,10 @@ The following options may be given as the first argument:
  Maximum allowed cumulated size of stored optimizer traces
  --optimizer-trace-offset=# 
  Offset of first optimizer trace to show; see manual
+ --ordered-commit-flush-logs-parellelly 
+ Flush binlog by a dedicated thread during flush stage of
+ ordered commit while flushing logs of storage engines.
+ (Defaults to off; use --skip-ordered-commit-flush-logs-parellelly to disable.)
  --parser-max-mem-size=# 
  Maximum amount of memory available to the parser
  --partial-revokes   Access of database objects can be restricted, even if
@@ -2258,6 +2262,7 @@ optimizer-trace-features greedy_search=on,range_optimizer=on,dynamic_range=on,re
 optimizer-trace-limit 1
 optimizer-trace-max-mem-size 1048576
 optimizer-trace-offset -1
+ordered-commit-flush-logs-parellelly FALSE
 parser-max-mem-size 18446744073709551615
 partial-revokes ####
 password-history 0

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_only_variables.result
@@ -24,7 +24,8 @@ VARIABLE_NAME LIKE '%semi_sync%' OR
 VARIABLE_NAME LIKE '%slave%' OR
 VARIABLE_NAME LIKE '%source%') AND
 (VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted'))
+'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted',
+'ordered_commit_flush_logs_parellelly'))
 ORDER BY VARIABLE_NAME;
 CREATE TABLE non_persisted (name VARCHAR(100) PRIMARY KEY);
 INSERT INTO non_persisted VALUES

--- a/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
+++ b/mysql-test/suite/binlog_nogtid/r/binlog_persist_variables.result
@@ -23,7 +23,8 @@ VARIABLE_NAME LIKE '%semi_sync%' OR
 VARIABLE_NAME LIKE '%slave%' OR
 VARIABLE_NAME LIKE '%source%') AND
 (VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted'))
+'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted',
+'ordered_commit_flush_logs_parellelly'))
 ORDER BY VARIABLE_NAME;
 
 include/assert.inc [Expect 126 variables in the table.]

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_only_variables.test
@@ -54,7 +54,8 @@ INSERT INTO rplvars (varname, varvalue)
         VARIABLE_NAME LIKE '%slave%' OR
         VARIABLE_NAME LIKE '%source%') AND
        (VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-        'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted'))
+        'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted',
+        'ordered_commit_flush_logs_parellelly'))
        ORDER BY VARIABLE_NAME;
 --enable_warnings
 --let $countvars= `SELECT COUNT(*) FROM rplvars;`

--- a/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
+++ b/mysql-test/suite/binlog_nogtid/t/binlog_persist_variables.test
@@ -54,7 +54,8 @@ INSERT INTO rplvars (varname, varvalue)
         VARIABLE_NAME LIKE '%slave%' OR
         VARIABLE_NAME LIKE '%source%') AND
        (VARIABLE_NAME NOT IN ('innodb_api_enable_binlog',
-        'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted'))
+        'innodb_master_thread_disabled_debug', 'innodb_replication_delay', 'gtid_undeleted',
+        'ordered_commit_flush_logs_parellelly'))
        ORDER BY VARIABLE_NAME;
 --enable_warnings
 --let $countvars = `SELECT COUNT(*) FROM rplvars;`

--- a/mysql-test/suite/perfschema/r/dml_setup_instruments.result
+++ b/mysql-test/suite/perfschema/r/dml_setup_instruments.result
@@ -42,6 +42,7 @@ where name like 'Wait/Synch/Cond/sql/%'
 order by name limit 10;
 NAME	ENABLED	TIMED	PROPERTIES	VOLATILITY	DOCUMENTATION
 wait/synch/cond/sql/Commit_order_manager::m_workers.cond	YES	YES		0	NULL
+wait/synch/cond/sql/cond_binlog_flush_thread	YES	YES		0	NULL
 wait/synch/cond/sql/COND_compress_gtid_table	YES	YES	singleton	0	NULL
 wait/synch/cond/sql/COND_connection_count	YES	YES	singleton	0	NULL
 wait/synch/cond/sql/COND_flush_thread_cache	YES	YES	singleton	0	NULL
@@ -50,7 +51,6 @@ wait/synch/cond/sql/COND_manager_state	YES	YES	singleton	0	NULL
 wait/synch/cond/sql/COND_queue_state	YES	YES	singleton	0	NULL
 wait/synch/cond/sql/COND_server_started	YES	YES	singleton	0	NULL
 wait/synch/cond/sql/COND_task_state	YES	YES	singleton	0	NULL
-wait/synch/cond/sql/COND_thd_list	YES	YES		0	NULL
 select * from performance_schema.setup_instruments
 where name='Wait';
 select * from performance_schema.setup_instruments

--- a/mysql-test/suite/sys_vars/r/all_vars.result
+++ b/mysql-test/suite/sys_vars/r/all_vars.result
@@ -292,6 +292,8 @@ num_seq_threads
 num_seq_threads
 optimizer_max_subgraph_pairs
 optimizer_max_subgraph_pairs
+ordered_commit_flush_logs_parellelly
+ordered_commit_flush_logs_parellelly
 partial_revokes
 partial_revokes
 partition_table_skip_limit

--- a/mysql-test/suite/sys_vars/r/tdsql_all_vars.result
+++ b/mysql-test/suite/sys_vars/r/tdsql_all_vars.result
@@ -292,6 +292,8 @@ num_seq_threads
 num_seq_threads
 optimizer_max_subgraph_pairs
 optimizer_max_subgraph_pairs
+ordered_commit_flush_logs_parellelly
+ordered_commit_flush_logs_parellelly
 partial_revokes
 partial_revokes
 partition_table_skip_limit

--- a/mysys/dbug.cc
+++ b/mysys/dbug.cc
@@ -318,7 +318,7 @@ static native_mutex_t THR_LOCK_gcov;
 */
 static native_rw_lock_t THR_LOCK_init_settings;
 
-static CODE_STATE *code_state(void) {
+CODE_STATE *code_state(void) {
   CODE_STATE *cs, **cs_ptr;
 
   if (!init_done) {
@@ -344,6 +344,14 @@ static CODE_STATE *code_state(void) {
     *cs_ptr = cs;
   }
   return cs;
+}
+
+void *get_cs_stack(CODE_STATE *cs) {
+  return (void *)cs->stack;
+}
+
+void set_cs_stack(CODE_STATE *cs_mod, void *stack) {
+  cs_mod->stack = (struct settings *)stack;
 }
 
 /**

--- a/share/messages_to_error_log.txt
+++ b/share/messages_to_error_log.txt
@@ -11904,6 +11904,12 @@ ER_IB_MSG_CLEAR_INSTANT_DROP_COLUMN_METADATA
 ER_STATEMENT_OUTLINE_LOAD_ERROR
  eng "Error when loading statement outline rules: %s"
 
+ER_BINLOG_INITIALIZE_FAILED
+  eng "Binlog fails to initialize for %s"
+
+ER_BINLOG_THREAD_JOIN_FAILED
+  eng "Could not join %s thread. error:%d"
+
 # DO NOT add server-to-client messages here;
 # they go in messages_to_clients.txt
 # in the same directory as this file.

--- a/sql/basic_ostream.cc
+++ b/sql/basic_ostream.cc
@@ -41,7 +41,7 @@ bool IO_CACHE_ostream::open(
                               MYF(MY_WME))) < 0)
     return true;
 
-  if (init_io_cache(&m_io_cache, file, IO_SIZE, WRITE_CACHE, 0, false, flags)) {
+  if (init_io_cache(&m_io_cache, file, IO_SIZE * 4, WRITE_CACHE, 0, false, flags)) {
     mysql_file_close(file, MYF(0));
     return true;
   }
@@ -60,6 +60,11 @@ bool IO_CACHE_ostream::close() {
 bool IO_CACHE_ostream::seek(my_off_t offset) {
   assert(my_b_inited(&m_io_cache));
   return reinit_io_cache(&m_io_cache, WRITE_CACHE, offset, false, true);
+}
+
+bool IO_CACHE_ostream::has_enough_space(my_off_t length) {
+  assert(my_b_inited(&m_io_cache));
+  return ((m_io_cache.write_pos + length) <= m_io_cache.write_end);
 }
 
 bool IO_CACHE_ostream::write(const unsigned char *buffer, my_off_t length) {

--- a/sql/basic_ostream.h
+++ b/sql/basic_ostream.h
@@ -33,7 +33,15 @@
 */
 class Basic_ostream {
  public:
-  /**
+   /**
+     Check if there is enough space for storing current data.
+
+     @retval false  Has no enough space
+     @retval true  Has enough space
+   */
+   virtual bool has_enough_space(my_off_t) { return true; }
+
+   /**
      Write some bytes into the output stream.
      When all data is written into the stream successfully, then it return
      false. Otherwise, true is returned. It will never returns false when
@@ -122,6 +130,16 @@ class IO_CACHE_ostream : public Truncatable_ostream {
      @retval true  Error
   */
   bool close();
+
+  /**
+     Check if there is enough space for storing current thread's binlog events.
+     When write buffer in IO_CACHE has no enough space, it returns false.
+
+     @param[in] length  Length of the data to write
+     @retval false  Has no enough space
+     @retval true  Has enough space
+  */
+  bool has_enough_space(my_off_t length) override;
 
   bool write(const unsigned char *buffer, my_off_t length) override;
   bool seek(my_off_t offset) override;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -178,6 +178,8 @@ ulong rpl_read_size;
 
 MYSQL_BIN_LOG mysql_bin_log(&sync_binlog_period);
 
+bool opt_oc_flush_logs_parallelly = false;
+
 static int binlog_init(void *p);
 static int binlog_start_trans_and_stmt(THD *thd, Log_event *start_event);
 static int binlog_close_connection(handlerton *hton, THD *thd);
@@ -515,6 +517,17 @@ class MYSQL_BIN_LOG::Binlog_ofile : public Basic_ostream {
   bool write(const unsigned char *buffer, my_off_t length) override {
     assert(m_pipeline_head != nullptr);
 
+    /*
+      Check if there is enough space for storing current thread's binlog events when flushing binlog in advance,
+      in case of writing binlog to disk in prior of engines' logs. If write buffer in IO_CACHE has no enough
+      space, wait until all engines' logs have been flushed. Then resume to write.
+      Only check the remaining cache size when flushing binlog events.
+    */
+    if (check_remaining_size && (!m_pipeline_head->has_enough_space(length))) {
+      /* Busy waiting for all engines' logs are flushed. */
+      mysql_bin_log.suspend_till_ha_flushed();
+    }
+
     if (m_pipeline_head->write(buffer, length)) return true;
 
     m_position += length;
@@ -601,6 +614,15 @@ class MYSQL_BIN_LOG::Binlog_ofile : public Basic_ostream {
   */
   void set_encrypted() { m_encrypted = true; }
   /**
+    Set if check the remaining cache size or not.
+    Only check the remaining cache size when flushing binlog event in advance.
+    @param[in] check True if need to check.
+  */
+  void set_check_remaining_size(bool check) {
+    check_remaining_size =
+        (check && mysql_bin_log.is_flush_logs_parallelly());
+  }
+  /**
    Return the encrypted version of binlog.
   */
   uint8_t get_encrypted_version() { return m_encrypted_version; }
@@ -610,6 +632,7 @@ class MYSQL_BIN_LOG::Binlog_ofile : public Basic_ostream {
   int m_encrypted_header_size = 0;
   std::unique_ptr<Truncatable_ostream> m_pipeline_head;
   bool m_encrypted = false;
+  bool check_remaining_size = false;
   uint8_t m_encrypted_version = 0;
 };
 
@@ -1419,6 +1442,11 @@ class Binlog_event_writer : public Basic_ostream {
         end_log_pos(binlog_file->position()) {
     // Simulate checksum error
     if (DBUG_EVALUATE_IF("fault_injection_crc_value", 1, 0)) checksum--;
+    set_check_remaining_size(true);
+  }
+
+  ~Binlog_event_writer() {
+    set_check_remaining_size(false);
   }
 
   void update_header() {
@@ -1491,6 +1519,8 @@ class Binlog_event_writer : public Basic_ostream {
     Returns true if per event checksum is enabled.
   */
   bool is_checksum_enabled() { return have_checksum; }
+
+  void set_check_remaining_size(bool check) { m_binlog_file->set_check_remaining_size(check); }
 };
 
 /*
@@ -3606,6 +3636,16 @@ void MYSQL_BIN_LOG::cleanup() {
     mysql_cond_destroy(&update_cond);
     mysql_cond_destroy(&m_prep_xids_cond);
     mysql_cond_destroy(&m_clear_flush_trxs_cond);
+
+    /*
+      LOCKs used during ordered commit have been destroyed at this point, there
+      will be no more access to them. So there will be no more requests to
+      dedicated threads and dedicated threads could exit.
+    */
+    if (m_dedicated_thread_status) {
+      terminate_all_binlog_threads();
+    }
+
     if (!is_relay_log) {
       Commit_stage_manager::get_instance().deinit();
     }
@@ -3635,6 +3675,142 @@ void MYSQL_BIN_LOG::init_pthread_objects() {
     Commit_stage_manager::get_instance().init(
         m_key_LOCK_flush_queue, m_key_LOCK_sync_queue, m_key_LOCK_commit_queue,
         m_key_LOCK_done, m_key_COND_done, m_key_COND_flush_queue);
+  }
+}
+
+void MYSQL_BIN_LOG::binlog_flush(ordered_commit_flush_thread *manager)
+{
+  mysql_mutex_assert_owner(&(manager->mutex_flush_thread));
+  my_off_t total_bytes = 0;
+  int flush_error = 1;
+#ifndef NDEBUG
+  // number of flushes per group.
+  int no_flushes = 0;
+#endif
+  Thd_backup_and_restore switch_thd(current_thd, manager->header_thd);
+
+  mysql_bin_log.assign_automatic_gtids_to_flush_group(manager->first_thd_in_group);
+
+  for (THD *head = manager->first_thd_in_group; head; head = head->next_to_commit) {
+    std::pair<int, my_off_t> result = mysql_bin_log.flush_thread_caches(head);
+    total_bytes += result.second;
+    if (flush_error == 1) flush_error = result.first;
+#ifndef NDEBUG
+    no_flushes++;
+#endif
+  }
+
+  /* Store the result. */
+  memset(&(manager->flush_thread_caches_result), 0, sizeof(manager->flush_thread_caches_result));
+  manager->flush_thread_caches_result.total_bytes = total_bytes;
+  manager->flush_thread_caches_result.flush_error = flush_error;
+#ifndef NDEBUG
+  manager->flush_thread_caches_result.no_flushes = no_flushes;
+#endif
+
+  manager->first_thd_in_group = nullptr;
+
+  return;
+}
+
+void *MYSQL_BIN_LOG::binlog_flush_worker(void *arg)
+{
+  my_thread_init();
+  DBUG_TRACE;
+
+  THD thd;
+  thd.thread_stack = (char *)&thd;
+  thd.store_globals();
+
+#ifndef NDEBUG
+  void *stack_origin;
+  struct CODE_STATE *cs_origin = code_state();
+  stack_origin = get_cs_stack(cs_origin);
+#endif
+
+  ordered_commit_flush_thread *mngr = (ordered_commit_flush_thread *)(arg);
+  mysql_mutex_lock(&(mngr->mutex_flush_thread));
+  for (;;) {
+    /*
+      Wait with predicate to avoid lost wakeup: if the producer has already
+      published first_thd_in_group before this thread starts waiting, skip wait
+      and process it directly.
+    */
+    while (mngr->first_thd_in_group == nullptr && !mngr->thread_exit) {
+      mysql_cond_wait(&(mngr->cond_flush_thread), &(mngr->mutex_flush_thread));
+    }
+
+    if (mngr->first_thd_in_group != nullptr) {
+#ifndef NDEBUG
+      set_cs_stack(cs_origin, get_cs_stack(mngr->cs_header_thread));
+#endif
+
+      mysql_bin_log.binlog_flush(mngr);
+      /*
+        Release: pairs with acquire load in process_flush_stage_queue so all
+        writes to flush_thread_caches_result in binlog_flush() are visible
+        before the leader reads them.
+      */
+      mngr->flush_thread_caches_done.store(true, std::memory_order_release);
+    }
+
+    /*
+      Check if the thread should exit. When "thread_exit" is set to true,
+      it indicates the server is under exiting and flush thread should exit.
+    */
+    if (mngr->thread_exit)
+      break;
+  }
+  mysql_mutex_unlock(&(mngr->mutex_flush_thread));
+
+#ifndef NDEBUG
+  set_cs_stack(cs_origin, stack_origin);
+#endif
+
+  my_thread_end();
+  my_thread_exit(nullptr);
+  return nullptr;
+}
+
+bool MYSQL_BIN_LOG::start_dedicated_threads(void) {
+  set_flush_logs_parallelly(opt_oc_flush_logs_parallelly);
+  if (opt_oc_flush_logs_parallelly) {
+    /* Initialize binlog flush thread. */
+    my_thread_attr_t attr_flush_thread;
+    (void)my_thread_attr_init(&attr_flush_thread);
+
+    binlog_flush_thread_mngr.init();
+    if (mysql_thread_create(key_thread_binlog_flush, &(binlog_flush_thread_mngr.thread_id),
+          &attr_flush_thread, binlog_flush_worker, (void *)(&(binlog_flush_thread_mngr)))) {
+        LogErr(ERROR_LEVEL, ER_BINLOG_INITIALIZE_FAILED, "create binlog flush thread");
+        binlog_flush_thread_mngr.deinit();
+        return true;
+    }
+    my_thread_attr_destroy(&attr_flush_thread);
+    /* Set "start" status when success to create flush thread. */
+    m_dedicated_thread_status |= ORDERED_COMMIT_FLUSH_THREAD_RUNNING;
+  }
+
+  return false;
+}
+
+/* Terminate all binlog handling threads(like binlog flush thread, binlog sync thread) when server exit. */
+void MYSQL_BIN_LOG::terminate_all_binlog_threads(void) {
+  if (opt_oc_flush_logs_parallelly) {
+    ordered_commit_flush_thread *mngr = &binlog_flush_thread_mngr;
+    /* If thread fails to be created, nothing to be done except deinit. */
+    if (m_dedicated_thread_status & ORDERED_COMMIT_FLUSH_THREAD_RUNNING) {
+      mysql_mutex_lock(&(mngr->mutex_flush_thread));
+      mngr->thread_exit = true;
+      mysql_cond_signal(&(mngr->cond_flush_thread));
+      mysql_mutex_unlock(&(mngr->mutex_flush_thread));
+
+      int error = my_thread_join(&(mngr->thread_id), nullptr);
+      mngr->thread_id.thread = 0;
+      if (error != 0)
+        LogErr(WARNING_LEVEL, ER_BINLOG_THREAD_JOIN_FAILED, "binlog flush", error);
+    }
+    mngr->deinit();
   }
 }
 
@@ -7569,7 +7745,7 @@ bool MYSQL_BIN_LOG::write_incident(Incident_log_event *ev, THD *thd,
                        0)) {
     if (need_lock_log)
       mysql_mutex_lock(&LOCK_log);
-    else
+    else if (!is_flush_logs_parallelly())
       mysql_mutex_assert_owner(&LOCK_log);
     /* Write an incident event into binlog directly. */
     error = write_event_to_binlog(ev);
@@ -7602,7 +7778,7 @@ bool MYSQL_BIN_LOG::write_incident(Incident_log_event *ev, THD *thd,
 
     if (need_lock_log)
       mysql_mutex_lock(&LOCK_log);
-    else
+    else if (!is_flush_logs_parallelly())
       mysql_mutex_assert_owner(&LOCK_log);
   }
 
@@ -7748,7 +7924,8 @@ bool MYSQL_BIN_LOG::write_cache(THD *thd, binlog_cache_data *cache_data,
   Binlog_cache_storage *cache = cache_data->get_cache();
   bool incident = cache_data->has_incident();
 
-  mysql_mutex_assert_owner(&LOCK_log);
+  if (!is_flush_logs_parallelly())
+    mysql_mutex_assert_owner(&LOCK_log);
 
   assert(is_open());
   if (likely(is_open()))  // Should always be true
@@ -8587,6 +8764,32 @@ THD *MYSQL_BIN_LOG::fetch_and_process_flush_stage_queue(
   Commit_stage_manager::get_instance().unlock_queue(
       Commit_stage_manager::BINLOG_FLUSH_STAGE);
 
+  if (is_flush_logs_parallelly() && !check_and_skip_flush_logs) {
+    ordered_commit_flush_thread *flush_mngr = &(binlog_flush_thread_mngr);
+    mysql_mutex_lock(&(flush_mngr->mutex_flush_thread));
+    if (!flush_mngr->thread_exit) {
+      /*
+        The status of handlertons's logs is only checked by binlog flush thread when IO cache
+        in m_binlog_file has no enough remaining space for wrting binlog events. And at this
+        point, binlog flush thread must be sleeping, or something error happened if it's waked.
+        So there is no need to add specific lock for updating status of handlertons's logs here.
+      */
+      set_ha_flushed_status(false);
+#ifndef NDEBUG
+      flush_mngr->cs_header_thread = code_state();
+#endif
+      flush_mngr->header_thd = current_thd;
+      assert(flush_mngr->first_thd_in_group == nullptr);
+      flush_mngr->first_thd_in_group = first_seen;
+      flush_mngr->flush_thread_caches_done.store(false);
+
+      mysql_cond_signal(&(flush_mngr->cond_flush_thread));
+    } else {
+      set_flush_logs_parallelly(false);
+    }
+    mysql_mutex_unlock(&(flush_mngr->mutex_flush_thread));
+  }
+
   if (!check_and_skip_flush_logs ||
       (check_and_skip_flush_logs && commit_order_thd != nullptr)) {
     /*
@@ -8595,6 +8798,14 @@ THD *MYSQL_BIN_LOG::fetch_and_process_flush_stage_queue(
       flushing them to binary log.
     */
     ha_flush_logs(true);
+  }
+
+  if (is_flush_logs_parallelly() && !check_and_skip_flush_logs) {
+    /*
+      If binlog flush thread is waiting for handlertons's logs to be flushed, then it can acquire such status
+      after the status is set to true by flush stage header thread here.
+    */
+    set_ha_flushed_status(true);
   }
 
   /*
@@ -8622,17 +8833,39 @@ int MYSQL_BIN_LOG::process_flush_stage_queue(my_off_t *total_bytes_var,
   THD *first_seen = fetch_and_process_flush_stage_queue();
   DBUG_EXECUTE_IF("crash_after_flush_engine_log", DBUG_SUICIDE(););
   CONDITIONAL_SYNC_POINT_FOR_TIMESTAMP("before_write_binlog");
-  assign_automatic_gtids_to_flush_group(first_seen);
-  /* Flush thread caches to binary log. */
-  for (THD *head = first_seen; head; head = head->next_to_commit) {
-    Thd_backup_and_restore switch_thd(current_thd, head);
-    std::pair<int, my_off_t> result = flush_thread_caches(head);
-    total_bytes += result.second;
-    if (flush_error == 1) flush_error = result.first;
-#ifndef NDEBUG
-    no_flushes++;
+  if (is_flush_logs_parallelly()) {
+    /* Check if flushing thread caches to binary log has been done. Wait until done! */
+    ordered_commit_flush_thread *mngr = &(binlog_flush_thread_mngr);
+    while (!mngr->flush_thread_caches_done.load(std::memory_order_acquire)) {
+#if defined(__i386__) || defined(__x86_64__)
+      __asm__ __volatile__("pause" ::: "memory");
+#else
+      __asm__ __volatile__("" ::: "memory");
 #endif
-    flush_trxs++;
+    }
+    mngr->flush_thread_caches_done.store(false, std::memory_order_relaxed);
+
+    total_bytes = mngr->flush_thread_caches_result.total_bytes;
+    flush_error = mngr->flush_thread_caches_result.flush_error;
+#ifndef NDEBUG
+    no_flushes = mngr->flush_thread_caches_result.no_flushes;
+#endif
+    for (THD *head = first_seen; head; head = head->next_to_commit) {
+      flush_trxs++;
+    }
+  } else {
+    assign_automatic_gtids_to_flush_group(first_seen);
+    /* Flush thread caches to binary log. */
+    for (THD *head = first_seen; head; head = head->next_to_commit) {
+      Thd_backup_and_restore switch_thd(current_thd, head);
+      std::pair<int, my_off_t> result = flush_thread_caches(head);
+      total_bytes += result.second;
+      if (flush_error == 1) flush_error = result.first;
+#ifndef NDEBUG
+      no_flushes++;
+#endif
+      flush_trxs++;
+    }
   }
 
   *out_queue_var = first_seen;

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -45,6 +45,7 @@
 #include "mysql/psi/mysql_mutex.h"
 #include "mysql/udf_registration_types.h"
 #include "mysql_com.h"  // Item_result
+#include "sql/mysqld.h"
 #include "sql/rpl_commit_stage_manager.h"
 #include "sql/rpl_trx_tracking.h"
 #include "sql/tc_log.h"            // TC_LOG
@@ -108,6 +109,8 @@ struct Binlog_user_var_event {
 #define LOG_CLOSE_INDEX 1
 #define LOG_CLOSE_TO_BE_OPENED 2
 #define LOG_CLOSE_STOP_EVENT 4
+
+extern bool opt_oc_flush_logs_parallelly;
 
 /*
   Note that we destroy the lock mutex in the destructor here.
@@ -964,6 +967,152 @@ class MYSQL_BIN_LOG : public TC_LOG {
   bool is_rotating_caused_by_incident;
 
   void init_max_time_and_gts(bool relay_log);
+
+ public:
+  /*
+    Create dedicated threads.
+  */
+  bool start_dedicated_threads(void);
+
+  /*
+    Notify dedicated threads to exit when server exit.
+  */
+  void terminate_all_binlog_threads(void);
+
+  /**
+    Set the status of flushing storage engines' logs.
+    @param status True if all storage engines' logs have been flushed, False
+    otherwise.
+  */
+  inline void set_ha_flushed_status(bool status) {
+    is_ha_flushed.store(status, std::memory_order_release);
+  }
+
+  /*
+    Suspend until storage engines' logs to be flushed.
+    @note This function is called by binlog flush thread to wait for the
+    storage engines' logs to be flushed.
+  */
+  void suspend_till_ha_flushed(void) {
+    while (!is_ha_flushed.load(std::memory_order_acquire)) {
+#if defined(__i386__) || defined(__x86_64__)
+      __asm__ __volatile__("pause" ::: "memory");
+#else
+      __asm__ __volatile__("" ::: "memory");
+#endif
+    }
+  }
+
+  /**
+    Check if binlog flush thread is enabled to flush binlog in advance.
+    @return True if binlog flush thread is enabled to flush binlog in advance,
+    False otherwise.
+  */
+  bool is_flush_logs_parallelly(void) {
+    return flush_logs_parallelly.load(std::memory_order_acquire);
+  }
+
+  /**
+    Set the status of flushing binlog in advance.
+    @param status True if binlog flush thread is enabled to flush binlog in
+    advance, False otherwise.
+  */
+  void set_flush_logs_parallelly(bool status) {
+    flush_logs_parallelly.store(status, std::memory_order_release);
+  }
+
+ private:
+  /* Indicate whether logs of all storage engines have been flushed. */
+  std::atomic<bool> is_ha_flushed{false};
+
+  /*
+    Time sequence of flushing binlog when enable dedicated threads to flush
+    binlog to disk:
+    flush stage leader: ------------flush engines' logs---(wait)----------------------
+                                  |                                ^
+                                  |flush req                       |flush done
+                                  |                                |
+                                  v                                |
+    flush thread:       ----------flush thread caches-----------------------------------
+  */
+  struct ordered_commit_flush_thread {
+    my_thread_handle thread_id; /* This is the thread flushing binlog. */
+    mysql_mutex_t mutex_flush_thread;
+    mysql_cond_t cond_flush_thread;
+
+#ifndef NDEBUG
+    struct CODE_STATE *cs_header_thread;
+#endif
+    THD *header_thd; /* Flush stage header thread. */
+
+    /*
+      The header thread in the flush group.
+      It should be always nullptr before the moment to trigger the flush thread
+      to flush binlog.
+    */
+    THD *first_thd_in_group;
+
+    /* Notify the thread to exit. */
+    bool thread_exit;
+
+    /*
+      Initialize as false. When binlog flush thread finishes flushing binlog,
+      set it as true. Then, ordered commit flush stage header thread acquires
+      result of flushing binlog and sets it as false again.
+    */
+    std::atomic<bool> flush_thread_caches_done;
+
+    /* Result of flushing binlog done by binlog flush thread. */
+    struct flush_binlog_result {
+      my_off_t total_bytes;
+      int flush_error;
+#ifndef NDEBUG
+      // number of flushes per group.
+      int no_flushes;
+#endif
+    } flush_thread_caches_result;
+
+    void init(void) {
+      thread_id.thread = 0;
+#ifndef NDEBUG
+      cs_header_thread = nullptr;
+#endif
+      header_thd = nullptr;
+      first_thd_in_group = nullptr;
+      thread_exit = false;
+      flush_thread_caches_done.store(false);
+
+      mysql_mutex_init(key_mutex_binlog_flush_thread, &mutex_flush_thread,
+                       MY_MUTEX_INIT_FAST);
+      mysql_cond_init(key_cond_binlog_flush_thread, &cond_flush_thread);
+    }
+
+    void deinit(void) {
+      header_thd = nullptr;
+      first_thd_in_group = nullptr;
+      mysql_mutex_destroy(&mutex_flush_thread);
+      mysql_cond_destroy(&cond_flush_thread);
+    }
+  };
+
+  /*
+    The start routine of the dedicated thread flushing binlog to global binlog
+    IO cache.
+  */
+  static void *binlog_flush_worker(void *arg);
+
+  /*
+    Called by the flush thread to flush binlog.
+  */
+  void binlog_flush(ordered_commit_flush_thread *manager);
+
+  std::atomic<bool> flush_logs_parallelly{false};
+  ordered_commit_flush_thread binlog_flush_thread_mngr;
+
+  enum { ORDERED_COMMIT_FLUSH_THREAD_RUNNING = 1 };
+
+  int m_dedicated_thread_status = 0;
+
   /* Changes from TXSQL start.*/
  private:
   ulong m_cur_bin_suffix;

--- a/sql/binlog_ostream.h
+++ b/sql/binlog_ostream.h
@@ -300,6 +300,16 @@ class Binlog_encryption_ostream : public Truncatable_ostream {
   */
   uint8_t get_header_version();
 
+  /**
+     Check if there is enough space for storing current thread's binlog events.
+     When write buffer in IO_CACHE has no enough space, it returns false.
+
+     @param[in] length  Length of the data to write
+     @retval false  Has no enough space
+     @retval true  Has enough space
+  */
+  bool has_enough_space(my_off_t length) override { return m_down_ostream->has_enough_space(length); }
+
  private:
   std::unique_ptr<Truncatable_ostream> m_down_ostream;
   std::unique_ptr<Rpl_encryption_header> m_header;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -7207,9 +7207,12 @@ static int init_server_components() {
 
   DBUG_EXECUTE_IF("total_ha_2pc_equals_2", total_ha_2pc = 2;);
   if (total_ha_2pc > 1 || (1 == total_ha_2pc && opt_bin_log)) {
-    if (opt_bin_log)
+    if (opt_bin_log) {
       tc_log = &mysql_bin_log;
-    else
+      if (mysql_bin_log.start_dedicated_threads()) {
+        unireg_abort(MYSQLD_ABORT_EXIT);
+      }
+    } else
       tc_log = &tc_log_mmap;
   }
 
@@ -12560,6 +12563,7 @@ PSI_mutex_key key_thd_timer_mutex;
 PSI_mutex_key key_commit_order_manager_mutex;
 PSI_mutex_key key_mutex_replica_worker_hash;
 PSI_mutex_key key_monitor_info_run_lock;
+PSI_mutex_key key_mutex_binlog_flush_thread;
 PSI_mutex_key key_LOCK_delegate_connection_mutex;
 PSI_mutex_key key_LOCK_group_replication_connection_mutex;
 PSI_mutex_key key_master_info_transmit_lock;
@@ -12654,6 +12658,7 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_LOCK_admin_tls_ctx_options, "LOCK_admin_tls_ctx_options", 0, 0, "A lock to control all of the --ssl-* CTX related command line options for administrative connection port"},
   { &key_LOCK_rotate_binlog_master_key, "LOCK_rotate_binlog_master_key", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_monitor_info_run_lock, "Source_IO_monitor::run_lock", 0, 0, PSI_DOCUMENT_ME},
+  { &key_mutex_binlog_flush_thread, "mutex_binlog_flush_thread", 0, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_delegate_connection_mutex, "LOCK_delegate_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_group_replication_connection_mutex, "LOCK_group_replication_connection_mutex", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
 { &key_LOCK_authentication_policy, "LOCK_authentication_policy", PSI_FLAG_SINGLETON, 0, "A lock to ensure execution of CREATE USER or ALTER USER sql and SET @@global.authentication_policy variable are serialized"},
@@ -12741,6 +12746,7 @@ PSI_cond_key key_COND_thd_done;
 PSI_cond_key key_commit_order_manager_cond;
 PSI_cond_key key_cond_slave_worker_hash;
 PSI_cond_key key_monitor_info_run_cond;
+PSI_cond_key key_cond_binlog_flush_thread;
 PSI_cond_key key_COND_delegate_connection_cond_var;
 PSI_cond_key key_COND_group_replication_connection_cond_var;
 
@@ -12785,6 +12791,7 @@ static PSI_cond_info all_server_conds[]=
   { &key_commit_order_manager_cond, "Commit_order_manager::m_workers.cond", 0, 0, PSI_DOCUMENT_ME},
   { &key_cond_slave_worker_hash, "Relay_log_info::replica_worker_hash_cond", 0, 0, PSI_DOCUMENT_ME},
   { &key_monitor_info_run_cond, "Source_IO_monitor::run_cond", 0, 0, PSI_DOCUMENT_ME},
+  { &key_cond_binlog_flush_thread, "cond_binlog_flush_thread", 0, 0, PSI_DOCUMENT_ME},
   { &key_COND_delegate_connection_cond_var, "THD::COND_delegate_connection_cond_var", 0, 0, PSI_DOCUMENT_ME},
   { &key_COND_group_replication_connection_cond_var, "THD::COND_group_replication_connection_cond_var", 0, 0, PSI_DOCUMENT_ME}
 };
@@ -12796,6 +12803,7 @@ PSI_thread_key key_thread_one_connection;
 PSI_thread_key key_thread_compress_gtid_table;
 PSI_thread_key key_thread_parser_service;
 PSI_thread_key key_thread_handle_con_admin_sockets;
+PSI_thread_key key_thread_binlog_flush;
 PSI_thread_key key_thread_sql_statistics_clear_expired_info;
 
 /* clang-format off */
@@ -12816,6 +12824,7 @@ PSI_FLAG_USER | PSI_FLAG_NO_SEQNUM, 0, PSI_DOCUMENT_ME},
   { &key_thread_compress_gtid_table, "compress_gtid_table", "gtid_zip", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_thread_parser_service, "parser_service", "parser_srv", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_thread_handle_con_admin_sockets, "admin_interface", "con_admin", PSI_FLAG_USER, 0, PSI_DOCUMENT_ME},
+  { &key_thread_binlog_flush, "binlog_flush", "binlog_flush", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_thread_sql_statistics_clear_expired_info, "sql_statistics", "sql_stat", PSI_FLAG_USER, 0, PSI_DOCUMENT_ME},
 };
 /* clang-format on */

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -540,6 +540,7 @@ extern PSI_mutex_key key_mta_temp_table_LOCK;
 extern PSI_mutex_key key_mta_gaq_LOCK;
 extern PSI_mutex_key key_thd_timer_mutex;
 extern PSI_mutex_key key_monitor_info_run_lock;
+extern PSI_mutex_key key_mutex_binlog_flush_thread;
 extern PSI_mutex_key key_LOCK_delegate_connection_mutex;
 extern PSI_mutex_key key_LOCK_group_replication_connection_mutex;
 
@@ -579,6 +580,7 @@ extern PSI_cond_key key_COND_thr_lock;
 extern PSI_cond_key key_COND_thd_done;
 extern PSI_cond_key key_cond_slave_worker_hash;
 extern PSI_cond_key key_commit_order_manager_cond;
+extern PSI_cond_key key_cond_binlog_flush_thread;
 extern PSI_cond_key key_COND_group_replication_connection_cond_var;
 extern PSI_thread_key key_thread_bootstrap;
 extern PSI_thread_key key_thread_handle_manager;
@@ -586,6 +588,7 @@ extern PSI_thread_key key_thread_one_connection;
 extern PSI_thread_key key_thread_compress_gtid_table;
 extern PSI_thread_key key_thread_parser_service;
 extern PSI_thread_key key_thread_handle_con_admin_sockets;
+extern PSI_thread_key key_thread_binlog_flush;
 extern PSI_cond_key key_monitor_info_run_cond;
 extern PSI_thread_key key_thread_sql_statistics_clear_expired_info;
 

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -7753,6 +7753,13 @@ static Sys_var_charptr Sys_authentication_policy(
 static Sys_var_deprecated_alias Sys_skip_slave_start("skip_slave_start",
                                                      Sys_skip_replica_start);
 
+static Sys_var_bool Sys_ordered_commit_flush_logs_parallelly(
+    "ordered_commit_flush_logs_parellelly",
+    "Flush binlog by a dedicated thread during flush stage of ordered commit "
+    "while flushing logs of storage engines.",
+    READ_ONLY GLOBAL_VAR(opt_oc_flush_logs_parallelly), CMD_LINE(OPT_ARG),
+    DEFAULT(false));
+
 static const char *terminology_use_previous_names[] = {"NONE", "BEFORE_8_0_26",
                                                        nullptr};
 


### PR DESCRIPTION
Optimize flush stage of group commit by flushing binlog and engine logs parallelly. The following figure shows the scheme design.
<img width="1890" height="1126" alt="flush阶段优化方案" src="https://github.com/user-attachments/assets/4881dbb8-473d-47b9-9ece-f1e0a20ef3f4" />
In the native design, redolog, GTID and binlog are processed serially. In the new design, GTID and binlog are processed parallelly with redolog. It should be emphasized that the new design still ensure that redolog is written to disk before binlog. By such parallel processing method, the time cost of flush stage of group commit could be reduced.
Code modifications:
1. Add a dedicated thread named binlog flush thread to assign GTID and flush binlog. It receives requests from flush stage header thread and gives response to flush stage header.
2. The size of IO write cache(used when collecting binlog events data of transactions in flush stage group)  is modified to 16KB from 8KB. The purpose is to reduce the probability of IO write cache being full while collecting binlog events.
3. Add a switch to enable/disable the feature and the default is disabled.