### PR TITLE
Bug#34708953 : Debug Assertion failure: row0upd.cc:496:!rec_get_insta…

### DIFF
--- a/storage/innobase/row/row0upd.cc
+++ b/storage/innobase/row/row0upd.cc
@@ -498,13 +498,13 @@ void row_upd_rec_in_place(
   ut_ad(!index->table->skip_alter_undo);
 
   if (rec_offs_comp(offsets)) {
-    bool is_instant = rec_get_instant_flag_new(rec);
-    bool is_versioned = rec_new_is_versioned(rec);
+    const bool is_instant = rec_get_instant_flag_new(rec);
+    const bool is_versioned = rec_new_is_versioned(rec);
 
     rec_set_info_bits_new(rec, update->info_bits);
     if (is_versioned) {
       rec_new_set_versioned(rec, true);
-      ut_ad(!rec_get_instant_flag_new(rec));
+      rec_set_instant_flag_new(rec, false);
     } else if (is_instant) {
       ut_ad(index->table->has_instant_cols());
       rec_set_instant_flag_new(rec, true);
@@ -522,6 +522,9 @@ void row_upd_rec_in_place(
       rec_old_set_versioned(rec, false);
     }
   }
+
+  /* Only one of the bit (INSTANT or VERSION) could be set */
+  ut_a(!(rec_get_instant_flag_new(rec) && rec_new_is_versioned(rec)));
 
   n_fields = upd_get_n_fields(update);
 


### PR DESCRIPTION
…nt_flag_new(rec)

cherry-pick from 2204ffca7598a1a0ac3e8b544ac3cfdd6b2ff235 by mayprasa

Background :
 In the previous implementation, a row R1 inserted after first instant
 ADD will have INSTANT bit set. After upgrade, if this row R1 is updated
 then :
 [1] Inplace update will keep the row in old format (instant bit set).
 [2] Not inpalce update will move the row to new format (version bit set)

Issue :
 If table has row vesion (i.e. new INSTANT ADD Column) then UPDATE won't
 be INPLACE (as newly added columns is to be materialized). So the row R1
 is transformed to "versioned record".
 But when the rollback is issued, (which is implemented as UPDATE), and if
 this is not changing row size (i.e. INPLACE update), then
 - Version bit is set => so the new record (rollbacked) record will also have version bit set. (update rule).
 - Because the INSTANT bit was set in UNDO update vector, it was also being set, which is wrong. So assertsion was hit.

Fix :
 When VERSION bit is being set for the record, make sure INSTANT bit is
 reset because record is going to be "versioned record" even after ROLLBACK.

Change-Id: Ia68127de75d9bc883576e7baf020d41f4376943d