### PR TITLE
[bugfix] issue#54 release pages in check index

### DIFF
--- a/storage/innobase/fsp/fsp0fsp.cc
+++ b/storage/innobase/fsp/fsp0fsp.cc
@@ -4984,6 +4984,8 @@ void fseg_get_pages_info(
   uint i;
   uint page_no;
   fil_addr_t node_addr;
+  ulint save_point;
+  ulint read_pages = 0;
 
   mtr_start(&mtr);
   fil_space_t *space = fil_space_get(space_id);
@@ -5011,9 +5013,15 @@ void fseg_get_pages_info(
     }
   }
 
+  save_point = mtr_set_savepoint(&mtr);
   /* Scan FSEG_NOT_FULL list */
   node_addr = flst_get_first(seg_inode + FSEG_NOT_FULL, &mtr);
   while (!fil_addr_is_null(node_addr)) {
+    if (++read_pages % 100 == 0) {
+      mtr_release_all_after_savepoint(&mtr, save_point);
+      read_pages = 0;
+      save_point = mtr_set_savepoint(&mtr);
+    }
     descr = xdes_lst_get_descriptor(space_id, page_size, node_addr, &mtr);
 
     if (mode == FSP_GET_TOTAL_CNT || mode == FSP_GET_BOTH) {
@@ -5035,6 +5043,11 @@ void fseg_get_pages_info(
   /* Scan FSEG_FULL list */
   node_addr = flst_get_first(seg_inode + FSEG_FULL, &mtr);
   while (!fil_addr_is_null(node_addr)) {
+    if (++read_pages % 100 == 0) {
+      mtr_release_all_after_savepoint(&mtr, save_point);
+      read_pages = 0;
+      save_point = mtr_set_savepoint(&mtr);
+    }
     descr = xdes_lst_get_descriptor(space_id, page_size, node_addr, &mtr);
 
     if (mode == FSP_GET_TOTAL_CNT || mode == FSP_GET_BOTH) {

--- a/storage/innobase/include/mtr0mtr.h
+++ b/storage/innobase/include/mtr0mtr.h
@@ -150,6 +150,9 @@ savepoint. */
 #define mtr_block_x_latch_at_savepoint(m, s, b) \
   (m)->x_latch_at_savepoint((s), (b))
 
+#define mtr_release_all_after_savepoint(m, s) \
+  (m)->release_all_after_savepoint((s))
+
 /** Check if a mini-transaction is dirtying a clean page.
 @param b        block being x-fixed
 @return true if the mtr is dirtying a clean page. */
@@ -486,6 +489,9 @@ struct mtr_t {
   @param[in]    ptr     pointer to within a page frame
   @param[in]    type    object type: MTR_MEMO_PAGE_X_FIX, ... */
   void release_page(const void *ptr, mtr_memo_type_t type);
+
+  /** Release the block in an mtr memo after a savepoint. */
+  void release_all_after_savepoint(ulint savepoint);
 
   /** Note that the mini-transaction has modified data. */
   void set_modified() { m_impl.m_modifications = true; }

--- a/storage/innobase/mtr/mtr0mtr.cc
+++ b/storage/innobase/mtr/mtr0mtr.cc
@@ -369,6 +369,38 @@ struct Add_dirty_blocks_to_flush_list {
   Flush_observer *const m_flush_observer;
 };
 
+struct Release_all_after_savepoint {
+  Release_all_after_savepoint(const ulint savepoint, ulint total_size)
+      : m_savepoint(savepoint), m_total_size(total_size), m_released(0) {}
+  bool operator()(mtr_buf_t::block_t *block) {
+    mtr_memo_slot_t *slot =
+        reinterpret_cast<mtr_memo_slot_t *>(block->begin());
+
+    const mtr_memo_slot_t *end =
+        reinterpret_cast<const mtr_memo_slot_t *>(block->end());
+
+    m_released += block->used();
+    if (m_released + m_savepoint >= m_total_size) {
+      ulint reserved = m_released + m_savepoint - m_total_size;
+      slot =
+          reinterpret_cast<mtr_memo_slot_t *>(block->begin() + reserved);
+    }
+    while (slot != end) {
+      if (slot->object != nullptr) {
+        memo_slot_release(slot);
+      }
+      slot++;
+    }
+    if (m_released + m_savepoint >= m_total_size)
+      return false;
+    return true;
+  }
+ private:
+  ulint m_savepoint;
+  ulint m_total_size;
+  ulint m_released{0};
+};
+
 /** Constructor.
 @param[in]      start_lsn       LSN of the first entry that was added
                                 to REDO by the MTR
@@ -765,6 +797,16 @@ void mtr_t::release_page(const void *ptr, mtr_memo_type_t type) {
 
   /* The page was not found! */
   ut_d(ut_error);
+}
+
+/** Release the block in an mtr memo after a savepoint. */
+void mtr_t::release_all_after_savepoint(ulint savepoint) {
+  ut_ad(is_active());
+  ut_ad(m_impl.m_magic_n == MTR_MAGIC_N);
+
+  Release_all_after_savepoint release_all(savepoint, get_savepoint());
+
+  m_impl.m_memo.for_each_block_in_reverse(release_all);
 }
 
 /** Prepare to write the mini-transaction log to the redo log buffer.


### PR DESCRIPTION
fseg_get_pages_info() did not release page latches during FSEG_NOT_FULL/FSEG_FULL extent iteration, causing excessive mtr memo growth and potential OOM for CHECK INDEX on large tables.

Fix: add mtr_release_all_after_savepoint() and release pages every 100 extents.