### PR TITLE
[bugfix] skip FTS_DOC_ID_INDEX in CHECK INDEX to avoid assert failure

### DIFF
--- a/mysql-test/suite/innodb/r/check_index.result
+++ b/mysql-test/suite/innodb/r/check_index.result
@@ -197,6 +197,24 @@ Table_name	Index_name	Type	Total_size	Usage_rate	Delete_rate	Btr_depth
 test.tmp_table	GEN_CLUST_INDEX	PRIMARY_INDEX	16384	0.008	0.000	1
 test.tmp_table	NULL	TABLE_LEVEL	16384	0.008	NULL	NULL
 drop table tmp_table;
+CREATE TABLE fts_test (
+`id` bigint NOT NULL,
+`k` bigint NOT NULL,
+`k1` bigint NOT NULL,
+`c` char(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+`pad` char(60) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+`tran_time` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+`body` text COLLATE utf8mb4_general_ci,
+PRIMARY KEY (`id`,`tran_time`),
+FULLTEXT KEY `tran_time` (`tran_time`,`body`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+check index from fts_test;
+Table_name	Index_name	Type	Total_size	Usage_rate	Delete_rate	Btr_depth
+test.fts_test	PRIMARY	PRIMARY_INDEX	16384	0.008	0.000	1
+test.fts_test	NULL	TABLE_LEVEL	16384	0.008	NULL	NULL
+Warnings:
+Warning	1235	Fulltext index is unsupported for check index. It will be omitted from the results list
+drop table fts_test;
 drop procedure load_t;
 drop table t;
 drop table t1;

--- a/mysql-test/suite/innodb/t/check_index.test
+++ b/mysql-test/suite/innodb/t/check_index.test
@@ -181,6 +181,21 @@ create temporary table tmp_table(id int, c1 int);
 check index from tmp_table;
 drop table tmp_table;
 
+CREATE TABLE fts_test (
+  `id` bigint NOT NULL,
+  `k` bigint NOT NULL,
+  `k1` bigint NOT NULL,
+  `c` char(120) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `pad` char(60) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
+  `tran_time` varchar(20) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `body` text COLLATE utf8mb4_general_ci,
+  PRIMARY KEY (`id`,`tran_time`),
+  FULLTEXT KEY `tran_time` (`tran_time`,`body`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+#--warning 1235
+check index from fts_test; 
+
+drop table fts_test;
 drop procedure load_t;
 drop table t;
 drop table t1;

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -26496,6 +26496,13 @@ bool ha_innobase::check_index(THD *thd) { /*!< in: user thread handle */
        index = index->next()) {
     if (index->type & DICT_FTS) continue;
 
+    if (strcmp(index->name, FTS_DOC_ID_INDEX_NAME) == 0) {
+      push_warning(thd, Sql_condition::SL_WARNING, ER_NOT_SUPPORTED_YET,
+                   "Fulltext index is unsupported for check index. It will be "
+                   "omitted from the results list");
+      continue;
+    }
+
     index_physical_info_t idx_info;
     int btr_depth = 0;
     if (innobase_get_index_status(index, m_prebuilt->table->space, &idx_info,


### PR DESCRIPTION
Skip the hidden FTS_DOC_ID_INDEX in ha_innobase::check_index() and emit a warning, same as DICT_FTS indexes. Otherwise processing this internal B-tree index triggers an assert.