### PR TITLE
[optimization] Enable AArch64 fast paths for unaligned memory access

### DIFF
--- a/storage/innobase/rem/rem0cmp.cc
+++ b/storage/innobase/rem/rem0cmp.cc
@@ -463,7 +463,8 @@ inline int cmp_data(ulint mtype, ulint prtype, bool is_asc, const byte *data1,
   int cmp;
 
   if (len > 0) {
-#if defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64
+#if defined __i386__ || defined __x86_64__ || defined _M_IX86 || \
+    defined _M_X64 || defined __aarch64__
     /* Compare the first bytes with a loop to avoid the call
     overhead of memcmp(). On x86 and x86-64, the GCC built-in
     (repz cmpsb) seems to be very slow, so we will be calling the
@@ -503,7 +504,8 @@ inline int cmp_data(ulint mtype, ulint prtype, bool is_asc, const byte *data1,
 
       data1 += len;
       data2 += len;
-#if defined __i386__ || defined __x86_64__ || defined _M_IX86 || defined _M_X64
+#if defined __i386__ || defined __x86_64__ || defined _M_IX86 || \
+    defined _M_X64 || defined __aarch64__
     }
 #endif /* IA32 or AMD64 */
   }

--- a/strings/ctype.cc
+++ b/strings/ctype.cc
@@ -952,7 +952,8 @@ size_t my_convert(char *to, size_t to_length, const CHARSET_INFO *to_cs,
 
   length = length2 = std::min(to_length, from_length);
 
-#if defined(__i386__) || defined(_WIN32) || defined(__x86_64__)
+#if defined(__i386__) || defined(_WIN32) || defined(__x86_64__) || \
+    defined(__aarch64__)
   /*
     Special loop for i386, it allows to refer to a
     non-aligned memory block as UINT32, which makes

--- a/unittest/gunit/alignment-t.cc
+++ b/unittest/gunit/alignment-t.cc
@@ -111,7 +111,8 @@ class Mem_compare_sint4_generic {
   }
 };
 
-#if defined(__i386__) || defined(__x86_64__) || defined(_WIN32)
+#if defined(__i386__) || defined(__x86_64__) || defined(_WIN32) || \
+    defined(__aarch64__)
 
 TEST_F(AlignmentTest, AlignedSort) {
   for (int ix = 0; ix < num_iterations; ++ix) {


### PR DESCRIPTION

[optimization] Enable AArch64 fast paths for unaligned memory access
Extend the unaligned-access fast paths to AArch64 in InnoDB row comparison and my_convert, and enable the corresponding alignment gunit coverage on AArch64.

[优化] 为 AArch64 启用非对齐内存访问快速路径
将 InnoDB 行比较和 my_convert 中的非对齐访问快速路径扩展到 AArch64，并在 AArch64 上启用相应的对齐 gunit 测试覆盖。

By leveraging unaligned memory access optimizations on the new Kunpeng 920 CPUs, the average performance of Sysbench read-only, read-write, and write-only workloads can be improved by 1%–2%.
通过在鲲鹏920新型号CPU上使用非对齐内存访问优化，可以使Sysbench只读、读写、只写场景平均性能提升1%~2%。

<img width="1141" height="623" alt="image" src="https://github.com/user-attachments/assets/54ebed10-a004-4e8f-8936-d96bbc836f13" />
