### PR TITLE
[bugfix]issue#255 conversion from myisam to innodb failed when create…

### DIFF
--- a/mysql-test/r/partition_myisam_to_innodb.result
+++ b/mysql-test/r/partition_myisam_to_innodb.result
@@ -1,0 +1,110 @@
+#
+# Prepare
+# 
+SET @save_myisam_conversion_innodb=@@myisam_conversion_innodb;
+SET @save_tencent_myisam_conversion_innodb=@@tencent_myisam_conversion_innodb;
+SET GLOBAL myisam_conversion_innodb=TRY;
+SET GLOBAL tencent_myisam_conversion_innodb=TRY;
+#
+# Run
+# 
+# case 1 table engine = all partition engine = myisam
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=MYISAM
+PARTITION BY RANGE( YEAR(purchased) ) (
+PARTITION p0 VALUES LESS THAN (1990) ENGINE=MYISAM,
+PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+PARTITION p2 VALUES LESS THAN (2000) ENGINE=MYISAM,
+PARTITION p3 VALUES LESS THAN (2005) ENGINE=MYISAM);
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int DEFAULT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `purchased` date DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+/*!50100 PARTITION BY RANGE (year(`purchased`))
+(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,
+ PARTITION p1 VALUES LESS THAN (1995) ENGINE = InnoDB,
+ PARTITION p2 VALUES LESS THAN (2000) ENGINE = InnoDB,
+ PARTITION p3 VALUES LESS THAN (2005) ENGINE = InnoDB) */
+drop table t1;
+case2 default storage engine = myisam
+SET @save_default_storage_engine=@@default_storage_engine;
+set default_storage_engine=MyISAM;
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) 
+PARTITION BY RANGE( YEAR(purchased) ) (
+PARTITION p0 VALUES LESS THAN (1990), 
+PARTITION p1 VALUES LESS THAN (1995),
+PARTITION p2 VALUES LESS THAN (2000),
+PARTITION p3 VALUES LESS THAN (2005));
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int DEFAULT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `purchased` date DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+/*!50100 PARTITION BY RANGE (year(`purchased`))
+(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,
+ PARTITION p1 VALUES LESS THAN (1995) ENGINE = InnoDB,
+ PARTITION p2 VALUES LESS THAN (2000) ENGINE = InnoDB,
+ PARTITION p3 VALUES LESS THAN (2005) ENGINE = InnoDB) */
+drop table t1;
+set default_storage_engine=@save_default_storage_engine;
+case3 table engine = partial engine = myisam
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=MYISAM
+PARTITION BY RANGE( YEAR(purchased) ) (
+PARTITION p0 VALUES LESS THAN (1990), 
+PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+PARTITION p2 VALUES LESS THAN (2000),
+PARTITION p3 VALUES LESS THAN (2005));
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int DEFAULT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `purchased` date DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+/*!50100 PARTITION BY RANGE (year(`purchased`))
+(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,
+ PARTITION p1 VALUES LESS THAN (1995) ENGINE = InnoDB,
+ PARTITION p2 VALUES LESS THAN (2000) ENGINE = InnoDB,
+ PARTITION p3 VALUES LESS THAN (2005) ENGINE = InnoDB) */
+drop table t1;
+case4 table engine != myisam and partial partition engine = myisam
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=InnoDB
+PARTITION BY RANGE( YEAR(purchased) ) (
+PARTITION p0 VALUES LESS THAN (1990), 
+PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+PARTITION p2 VALUES LESS THAN (2000),
+PARTITION p3 VALUES LESS THAN (2005));
+ERROR HY000: The mix of handlers in the partitions is not allowed in this version of MySQL
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE)
+PARTITION BY RANGE( YEAR(purchased) ) (
+PARTITION p0 VALUES LESS THAN (1990), 
+PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+PARTITION p2 VALUES LESS THAN (2000),
+PARTITION p3 VALUES LESS THAN (2005));
+ERROR HY000: The mix of handlers in the partitions is not allowed in this version of MySQL
+case5 alter table ddl
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=MYISAM
+PARTITION BY RANGE( YEAR(purchased) ) (
+PARTITION p0 VALUES LESS THAN (1990), 
+PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+PARTITION p2 VALUES LESS THAN (2000),
+PARTITION p3 VALUES LESS THAN (2005));
+show create table t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int DEFAULT NULL,
+  `name` varchar(50) DEFAULT NULL,
+  `purchased` date DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+/*!50100 PARTITION BY RANGE (year(`purchased`))
+(PARTITION p0 VALUES LESS THAN (1990) ENGINE = InnoDB,
+ PARTITION p1 VALUES LESS THAN (1995) ENGINE = InnoDB,
+ PARTITION p2 VALUES LESS THAN (2000) ENGINE = InnoDB,
+ PARTITION p3 VALUES LESS THAN (2005) ENGINE = InnoDB) */
+alter table t1 add partition (partition p4 values less than (2007) engine=MyISAM);
+ERROR HY000: The mix of handlers in the partitions is not allowed in this version of MySQL
+drop table t1;

--- a/mysql-test/t/partition_myisam_to_innodb-master.opt
+++ b/mysql-test/t/partition_myisam_to_innodb-master.opt
@@ -1,0 +1,1 @@
+--tencent-root-cnf=tmy.conf

--- a/mysql-test/t/partition_myisam_to_innodb.test
+++ b/mysql-test/t/partition_myisam_to_innodb.test
@@ -1,0 +1,84 @@
+--source include/have_log_bin.inc
+--source include/have_myisam.inc
+
+--echo #
+--echo # Prepare
+--echo # 
+
+connect (con_tencentroot, localhost, tencentroot,'', );
+--connection con_tencentroot
+SET @save_myisam_conversion_innodb=@@myisam_conversion_innodb;
+SET @save_tencent_myisam_conversion_innodb=@@tencent_myisam_conversion_innodb;
+SET GLOBAL myisam_conversion_innodb=TRY;
+SET GLOBAL tencent_myisam_conversion_innodb=TRY;
+
+--echo #
+--echo # Run
+--echo # 
+
+connection default;
+
+--echo # case 1 table engine = all partition engine = myisam
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=MYISAM
+  PARTITION BY RANGE( YEAR(purchased) ) (
+  PARTITION p0 VALUES LESS THAN (1990) ENGINE=MYISAM,
+  PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+  PARTITION p2 VALUES LESS THAN (2000) ENGINE=MYISAM,
+  PARTITION p3 VALUES LESS THAN (2005) ENGINE=MYISAM);
+
+show create table t1;
+drop table t1;
+
+--echo case2 default storage engine = myisam
+SET @save_default_storage_engine=@@default_storage_engine;
+set default_storage_engine=MyISAM;
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) 
+  PARTITION BY RANGE( YEAR(purchased) ) (
+  PARTITION p0 VALUES LESS THAN (1990), 
+  PARTITION p1 VALUES LESS THAN (1995),
+  PARTITION p2 VALUES LESS THAN (2000),
+  PARTITION p3 VALUES LESS THAN (2005));
+show create table t1;
+drop table t1;
+set default_storage_engine=@save_default_storage_engine;
+
+--echo case3 table engine = partial engine = myisam
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=MYISAM
+  PARTITION BY RANGE( YEAR(purchased) ) (
+  PARTITION p0 VALUES LESS THAN (1990), 
+  PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+  PARTITION p2 VALUES LESS THAN (2000),
+  PARTITION p3 VALUES LESS THAN (2005));
+show create table t1;
+drop table t1;
+
+--echo case4 table engine != myisam and partial partition engine = myisam
+--error ER_MIX_HANDLER_ERROR
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=InnoDB
+  PARTITION BY RANGE( YEAR(purchased) ) (
+  PARTITION p0 VALUES LESS THAN (1990), 
+  PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+  PARTITION p2 VALUES LESS THAN (2000),
+  PARTITION p3 VALUES LESS THAN (2005));
+
+--error ER_MIX_HANDLER_ERROR
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE)
+  PARTITION BY RANGE( YEAR(purchased) ) (
+  PARTITION p0 VALUES LESS THAN (1990), 
+  PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+  PARTITION p2 VALUES LESS THAN (2000),
+  PARTITION p3 VALUES LESS THAN (2005));
+
+--echo case5 alter table ddl
+CREATE TABLE t1 (id INT, name VARCHAR(50), purchased DATE) ENGINE=MYISAM
+  PARTITION BY RANGE( YEAR(purchased) ) (
+  PARTITION p0 VALUES LESS THAN (1990), 
+  PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM,
+  PARTITION p2 VALUES LESS THAN (2000),
+  PARTITION p3 VALUES LESS THAN (2005));
+show create table t1;
+--error ER_MIX_HANDLER_ERROR
+alter table t1 add partition (partition p4 values less than (2007) engine=MyISAM);
+
+drop table t1;
+

--- a/sql/partition_info.cc
+++ b/sql/partition_info.cc
@@ -1108,6 +1108,50 @@ error:
   return true;
 }
 
+static bool check_and_set_engine_type(THD *thd, partition_element *p_elem) {
+  DBUG_TRACE;
+
+  if (p_elem->engine_type && p_elem->engine_type->db_type == DB_TYPE_MYISAM) {
+    p_elem->engine_type = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+  }
+  return false;
+}
+
+/*
+  convert myisam to innodb
+*/
+
+bool partition_info::convert_engine_type(THD *thd) {
+  uint n_parts = partitions.elements;
+  DBUG_TRACE;
+
+  if (n_parts) {
+    List_iterator<partition_element> part_it(partitions);
+    uint i = 0;
+    do {
+      partition_element *part_elem = part_it++;
+
+      if (is_sub_partitioned() && part_elem->subpartitions.elements) {
+        uint n_subparts = part_elem->subpartitions.elements;
+        uint j = 0;
+        List_iterator<partition_element> sub_it(part_elem->subpartitions);
+        do {
+          partition_element *sub_elem = sub_it++;
+          if (check_and_set_engine_type(thd, sub_elem))
+            goto error;
+        } while (++j < n_subparts);
+        /* ensure that the partition also has correct engine */
+        if (check_and_set_engine_type(thd, part_elem))
+          goto error;
+      } else if (check_and_set_engine_type(thd, part_elem))
+        goto error;
+    } while (++i < n_parts);
+  }
+  return false;
+error:
+  return true;
+}
+
 /*
   This routine allocates an array for all range constants to achieve a fast
   check what partition a certain value belongs to. At the same time it does

--- a/sql/partition_info.h
+++ b/sql/partition_info.h
@@ -571,6 +571,7 @@ class partition_info {
   char *find_duplicate_field();
   const char *find_duplicate_name();
   bool check_engine_mix(handlerton *engine_type, bool default_engine);
+  bool convert_engine_type(THD *thd);
   bool check_range_constants(THD *thd);
   bool check_list_constants(THD *thd);
   bool check_partition_info(THD *thd, handlerton **eng_type, handler *file,

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -10136,6 +10136,7 @@ void mysql_convert_table_myisam_to_innodb(THD *thd, const char *type,
     switch (tmp_myisam_conversion_innodb) {
       case CONVERSION_MODE_TRY:
         db_type = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+        if (thd->lex->part_info) thd->lex->part_info->convert_engine_type(thd);
         create_info->used_fields |= HA_CREATE_USED_ENGINE;
         converted = true;
         sql_print_information(
@@ -10151,6 +10152,7 @@ void mysql_convert_table_myisam_to_innodb(THD *thd, const char *type,
                                 ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB)),
                             table);
         db_type = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+        if (thd->lex->part_info) thd->lex->part_info->convert_engine_type(thd);
         create_info->used_fields |= HA_CREATE_USED_ENGINE;
         sql_print_information(
             "%s %s db:[%s],tb[%s]"
@@ -10159,6 +10161,7 @@ void mysql_convert_table_myisam_to_innodb(THD *thd, const char *type,
         break;
       case CONVERSION_MODE_ON:
         db_type = ha_resolve_by_legacy_type(thd, DB_TYPE_INNODB);
+        if (thd->lex->part_info) thd->lex->part_info->convert_engine_type(thd);
         create_info->used_fields |= HA_CREATE_USED_ENGINE;
         sql_print_information(
             "%s %s db:[%s],tb[%s]"


### PR DESCRIPTION
… partition table

Problem:
========
when myisam_conversion_innodb and tencent_myisam_conversion_innodb are opened in instance, user execute following statement will fail.

CREATE TABLE trb9 (id INT, name VARCHAR(50), purchased DATE) ENGINE=MYISAM PARTITION BY RANGE( YEAR(purchased) ) (
PARTITION p0 VALUES LESS THAN (1990) ENGINE=MYISAM, PARTITION p1 VALUES LESS THAN (1995) ENGINE=MYISAM, PARTITION p2 VALUES LESS THAN (2000) ENGINE=MYISAM, PARTITION p3 VALUES LESS THAN (2005) ENGINE=MYISAM );

the reason for this problem is that myisam_conversion_innodb only convert the table engine to innodb but the partition engine still be myisam so table engine and partition engine are different.

Solution:
=========
Convert partition engine to innodb if it is myisam.