### PR TITLE
[bugfix] #62 Fix sort_merge_join hint crash when used at query block …

### DIFF
--- a/mysql-test/r/join_outer_smj.result
+++ b/mysql-test/r/join_outer_smj.result
@@ -3205,3 +3205,120 @@ id	b	id
 136	564	564
 137	NULL	NULL
 DROP TABLE t1, t2;
+#
+# sort_merge_join hint
+#
+create table t1 (c int, b int);
+create table t2 (a int, b int);
+create table t3 (b int, c int);
+insert into t1 values (10,1);
+insert into t1 values (3 ,1);
+insert into t1 values (3 ,2);
+insert into t2 values (2, 1);
+insert into t2 values (3, 1);
+insert into t3 values (1, 3);
+insert into t3 values (1,10);
+ANALYZE TABLE t1, t2, t3;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+test.t2	analyze	status	OK
+test.t3	analyze	status	OK
+EXPLAIN select *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	NULL
+1	SIMPLE	t3	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where; Using join buffer (hash join)
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Using join buffer (hash join)
+Warnings:
+Note	1003	/* select#1 */ select `test`.`t1`.`c` AS `c`,`test`.`t1`.`b` AS `b`,`test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t3`.`b` AS `b`,`test`.`t3`.`c` AS `c` from `test`.`t1` join `test`.`t2` join `test`.`t3` where ((`test`.`t3`.`b` = `test`.`t2`.`b`) and (`test`.`t1`.`b` = `test`.`t2`.`b`) and (`test`.`t1`.`c` = `test`.`t3`.`c`))
+EXPLAIN FORMAT=TREE select *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+EXPLAIN
+-> Inner hash join (t1.b = t2.b), (t1.c = t3.c)  (cost=***.** rows=**)
+    -> Table scan on t1  (cost=***.** rows=**)
+    -> Hash
+        -> Inner hash join (t3.b = t2.b)  (cost=***.** rows=**)
+            -> Table scan on t3  (cost=***.** rows=**)
+            -> Hash
+                -> Table scan on t2  (cost=***.** rows=**)
+
+select *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+c	b	a	b	b	c
+10	1	2	1	1	10
+10	1	3	1	1	10
+3	1	2	1	1	3
+3	1	3	1	1	3
+# qb level hint
+EXPLAIN select /*+sort_merge_join()*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	NULL
+1	SIMPLE	t3	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where; Using join buffer (hash join)
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Using join buffer (hash join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ SORT_MERGE_JOIN(@`select#1`) */ `test`.`t1`.`c` AS `c`,`test`.`t1`.`b` AS `b`,`test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t3`.`b` AS `b`,`test`.`t3`.`c` AS `c` from `test`.`t1` join `test`.`t2` join `test`.`t3` where ((`test`.`t3`.`b` = `test`.`t2`.`b`) and (`test`.`t1`.`b` = `test`.`t2`.`b`) and (`test`.`t1`.`c` = `test`.`t3`.`c`))
+EXPLAIN FORMAT=TREE select /*+sort_merge_join()*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+EXPLAIN
+-> Inner hash join (t1.b = t2.b), (t1.c = t3.c)  (cost=***.** rows=**)
+    -> Table scan on t1  (cost=***.** rows=**)
+    -> Hash
+        -> Inner hash join (t3.b = t2.b)  (cost=***.** rows=**)
+            -> Table scan on t3  (cost=***.** rows=**)
+            -> Hash
+                -> Table scan on t2  (cost=***.** rows=**)
+
+select /*+sort_merge_join()*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+c	b	a	b	b	c
+10	1	2	1	1	10
+10	1	3	1	1	10
+3	1	2	1	1	3
+3	1	3	1	1	3
+# table level hint
+EXPLAIN select /*+sort_merge_join(t1,t2,t3)*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	SIMPLE	t2	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	NULL
+1	SIMPLE	t3	NULL	ALL	NULL	NULL	NULL	NULL	2	100.00	Using where; Using join buffer (hash join)
+1	SIMPLE	t1	NULL	ALL	NULL	NULL	NULL	NULL	3	100.00	Using where; Using join buffer (hash join)
+Warnings:
+Note	1003	/* select#1 */ select /*+ SORT_MERGE_JOIN(`t1`@`select#1`) SORT_MERGE_JOIN(`t2`@`select#1`) SORT_MERGE_JOIN(`t3`@`select#1`) */ `test`.`t1`.`c` AS `c`,`test`.`t1`.`b` AS `b`,`test`.`t2`.`a` AS `a`,`test`.`t2`.`b` AS `b`,`test`.`t3`.`b` AS `b`,`test`.`t3`.`c` AS `c` from `test`.`t1` join `test`.`t2` join `test`.`t3` where ((`test`.`t3`.`b` = `test`.`t2`.`b`) and (`test`.`t1`.`b` = `test`.`t2`.`b`) and (`test`.`t1`.`c` = `test`.`t3`.`c`))
+EXPLAIN FORMAT=TREE select /*+sort_merge_join(t1,t2,t3)*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+EXPLAIN
+-> Inner hash join (t1.b = t2.b), (t1.c = t3.c)  (cost=***.** rows=**)
+    -> Table scan on t1  (cost=***.** rows=**)
+    -> Hash
+        -> Inner hash join (t3.b = t2.b)  (cost=***.** rows=**)
+            -> Table scan on t3  (cost=***.** rows=**)
+            -> Hash
+                -> Table scan on t2  (cost=***.** rows=**)
+
+select /*+sort_merge_join(t1,t2,t3)*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+c	b	a	b	b	c
+10	1	2	1	1	10
+10	1	3	1	1	10
+3	1	2	1	1	3
+3	1	3	1	1	3
+drop table t1, t2, t3;

--- a/mysql-test/t/join_outer_smj.test
+++ b/mysql-test/t/join_outer_smj.test
@@ -2367,4 +2367,51 @@ ANALYZE TABLE t1, t2;
 SELECT * FROM t1 LEFT JOIN t2 ON t1.b = t2.id GROUP BY t1.id;
 DROP TABLE t1, t2;
 
+--echo #
+--echo # sort_merge_join hint
+--echo #
+create table t1 (c int, b int);
+create table t2 (a int, b int);
+create table t3 (b int, c int);
+insert into t1 values (10,1);
+insert into t1 values (3 ,1);
+insert into t1 values (3 ,2);
+insert into t2 values (2, 1);
+insert into t2 values (3, 1);
+insert into t3 values (1, 3);
+insert into t3 values (1,10);
+ANALYZE TABLE t1, t2, t3;
+
+let $query = select *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+--eval EXPLAIN $query
+--replace_regex /cost=[0-9.e\-]+\ rows=[0-9.e\-]+/cost=***.** rows=**/ /rows=[0-9]+/rows=***/
+--eval EXPLAIN FORMAT=TREE $query
+--eval $query
+
+--echo # qb level hint
+let $query = select /*+sort_merge_join()*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+--eval EXPLAIN $query
+--replace_regex /cost=[0-9.e\-]+\ rows=[0-9.e\-]+/cost=***.** rows=**/ /rows=[0-9]+/rows=***/
+--eval EXPLAIN FORMAT=TREE $query
+--eval $query
+
+
+--echo # table level hint
+let $query = select /*+sort_merge_join(t1,t2,t3)*/ *
+from t1
+inner join t2 on t1.b=t2.b
+inner join t3 on t3.c = t1.c and t3.b = t2.b;
+--eval EXPLAIN $query
+--replace_regex /cost=[0-9.e\-]+\ rows=[0-9.e\-]+/cost=***.** rows=**/ /rows=[0-9]+/rows=***/
+--eval EXPLAIN FORMAT=TREE $query
+--eval $query
+
+drop table t1, t2, t3;
+
 --source include/close_sort_merge_join.inc

--- a/sql/opt_hints.cc
+++ b/sql/opt_hints.cc
@@ -85,7 +85,7 @@ struct st_opt_hint_info opt_hint_info[] = {
     {"GROUP_INDEX", false, false, false},
     {"ORDER_INDEX", false, false, false},
     {"DERIVED_CONDITION_PUSHDOWN", true, true, false},
-    {"SORT_MERGE_JOIN", false, false, false},
+    {"SORT_MERGE_JOIN", true, true, false},
 #if defined(HAVE_PX)
     {"PARALLEL", false, false, false},
     {"PARALLEL", false, true, false},
@@ -616,8 +616,7 @@ bool is_compound_hint(opt_hints_enum type_arg) {
   return (
       type_arg == INDEX_MERGE_HINT_ENUM || type_arg == SKIP_SCAN_HINT_ENUM ||
       type_arg == INDEX_HINT_ENUM || type_arg == JOIN_INDEX_HINT_ENUM ||
-      type_arg == GROUP_INDEX_HINT_ENUM || type_arg == ORDER_INDEX_HINT_ENUM ||
-      type_arg == SORT_MERGE_JOIN_HINT_ENUM
+      type_arg == GROUP_INDEX_HINT_ENUM || type_arg == ORDER_INDEX_HINT_ENUM
 #if defined(HAVE_PX)
       || type_arg == PARALLEL_HINT_ENUM
 #endif

--- a/sql/opt_hints.h
+++ b/sql/opt_hints.h
@@ -687,8 +687,7 @@ class Opt_hints_table : public Opt_hints {
     if (type_arg == INDEX_MERGE_HINT_ENUM) return &index_merge;
     if (type_arg == SKIP_SCAN_HINT_ENUM) return &skip_scan;
     if (type_arg == INDEX_HINT_ENUM) return &index;
-    if (type_arg == JOIN_INDEX_HINT_ENUM ||
-        type_arg == SORT_MERGE_JOIN_HINT_ENUM) return &join_index;
+    if (type_arg == JOIN_INDEX_HINT_ENUM) return &join_index;
     if (type_arg == GROUP_INDEX_HINT_ENUM) return &group_index;
     if (type_arg == ORDER_INDEX_HINT_ENUM) return &order_index;
     assert(0);


### PR DESCRIPTION
…level

Problem:
========
SORT_MERGE_JOIN hint was incorrectly registered as a non-QB-level, non-switch hint (false, false in opt_hint_info), and was also incorrectly treated as a compound hint in is_compound_hint() and get_complex_hints(). When SORT_MERGE_JOIN was used at query block level (e.g., /+sort_merge_join()/), calling get_complex_hints() would crash because the hint type was routed to the compound hint path (via Opt_hints_table::get_compound_key_hint()), which returned an invalid pointer for SORT_MERGE_JOIN_HINT_ENUM.

Solution:
=========
Changed SORT_MERGE_JOIN opt_hint_info to (true, true) to properly support QB-level and switch semantics, consistent with similar hints like DERIVED_CONDITION_PUSHDOWN.
Removed SORT_MERGE_JOIN_HINT_ENUM from is_compound_hint() since it is not a compound (index-based) hint.
Removed the SORT_MERGE_JOIN_HINT_ENUM case from
Opt_hints_table::get_compound_key_hint_type_for_set() to avoid returning an incorrect join_index pointer.