### PR TITLE
[bugfix] issue#68 Fix CLEAR RECYCLE_BIN BEFORE TIMESTAMP filtering by…

### DIFF
--- a/mysql-test/r/recycle_bin_clear.result
+++ b/mysql-test/r/recycle_bin_clear.result
@@ -1,0 +1,42 @@
+set global txsql_recycle_bin_enabled=on;
+drop table if exists t1;
+create table t1(a int);
+use <RECYCLE_DATABASE>;
+insert into test.t1 values (11);
+truncate table test.t1;
+insert into test.t1 values (22);
+truncate table test.t1;
+insert into test.t1 values (33);
+drop table test.t1;
+show recycle_bin;
+db	table	recycle_table	drop_time	purge_time
+test	t1	#	#	#
+test	t1	#	#	#
+test	t1	#	#	#
+CLEAR RECYCLE_BIN test.t1 BEFORE TIMESTAMP('ts3');
+show recycle_bin;
+db	table	recycle_table	drop_time	purge_time
+test	t1	#	#	#
+test	t1	#	#	#
+RESTORE test.t1 FROM RECYCLE_BIN WITH TIMESTAMP('ts2');
+select * from test.t1;
+a
+22
+truncate table test.t1;
+insert into test.t1 values (44);
+drop table test.t1;
+CLEAR RECYCLE_BIN ALL test.t1 BEFORE TIMESTAMP('ts5');
+show recycle_bin;
+db	table	recycle_table	drop_time	purge_time
+test	t1	#	#	#
+CLEAR RECYCLE_BIN test.t1 BEFORE TIMESTAMP('ts5');
+ERROR HY000: No corresponding record was found in recycle_bin.
+RESTORE test.t1 FROM RECYCLE_BIN WITH TIMESTAMP('ts5');
+select * from test.t1;
+a
+44
+show recycle_bin;
+db	table	recycle_table	drop_time	purge_time
+drop table test.t1;
+clear recycle_bin;
+set global txsql_recycle_bin_enabled = default;

--- a/mysql-test/t/recycle_bin_clear.test
+++ b/mysql-test/t/recycle_bin_clear.test
@@ -1,0 +1,80 @@
+connect (con_root_master, localhost, root,,,,$MASTER_MYSOCK);
+set global txsql_recycle_bin_enabled=on;
+
+let $recycle_database = __txsql_recycle_bin__;
+
+drop table if exists t1;
+create table t1(a int);
+
+--replace_regex /__.*_recycle_bin__/<RECYCLE_DATABASE>/
+--eval use $recycle_database
+insert into test.t1 values (11);
+truncate table test.t1;
+
+sleep 1;
+insert into test.t1 values (22);
+truncate table test.t1;
+
+sleep 1;
+insert into test.t1 values (33);
+drop table test.t1;
+--replace_column 3 # 4 # 5 #
+show recycle_bin;
+
+# now we have 3 tables in recycle bin
+# test.t1 with data 11, drop_time = ts1
+# test.t1 with data 22, drop_time = ts2
+# test.t1 with data 33, drop_time = ts3
+# and meets condition ts1 < ts2 < ts3
+
+# let last_drop_time = ts3
+# clear recycle_bin test.t1 before timestamp(ts3) will clear record ts1
+--let $last_drop_time= query_get_value("select drop_time from mysql.recycle_bin_info where origin_schema='test' and origin_table='t1' order by drop_time desc limit 1", drop_time, 1)
+--replace_regex /'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'/'ts3'/
+--eval CLEAR RECYCLE_BIN test.t1 BEFORE TIMESTAMP('$last_drop_time')
+
+--replace_column 3 # 4 # 5 #
+show recycle_bin;
+
+# let first_drop_time = ts3
+# restore test.t1 from recycle_bin test.t1 with timestamp(ts3) will recover record ts2
+--let $first_drop_time= query_get_value("select drop_time from mysql.recycle_bin_info where origin_schema='test' and origin_table='t1' order by drop_time asc limit 1", drop_time, 1)
+--replace_regex /'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'/'ts2'/
+--eval RESTORE test.t1 FROM RECYCLE_BIN WITH TIMESTAMP('$first_drop_time')
+
+select * from test.t1;
+
+# drop generate one more recycle bin record with ts4, ts3 < ts4
+truncate table test.t1;
+
+insert into test.t1 values (44);
+sleep 1;
+# drop generate one more recycle bin record with ts5, ts4 < ts5
+drop table test.t1;
+
+# let last_drop_time = ts5
+# clear recycle_bin all test.t1 before timestamp(ts5) will clear record ts3, ts4
+--let $last_drop_time= query_get_value("select drop_time from mysql.recycle_bin_info where origin_schema='test' and origin_table='t1' order by drop_time desc limit 1", drop_time, 1)
+--replace_regex /'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'/'ts5'/
+--eval CLEAR RECYCLE_BIN ALL test.t1 BEFORE TIMESTAMP('$last_drop_time')
+
+--replace_column 3 # 4 # 5 #
+show recycle_bin;
+
+# no records to clear before ts5
+--replace_regex /'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'/'ts5'/
+--error ER_RECYCLE_BIN_NOT_FOUND
+--eval CLEAR RECYCLE_BIN test.t1 BEFORE TIMESTAMP('$last_drop_time')
+
+# restore test.t1 from recycle_bin test.t1 with timestamp(ts4) will recover record ts5
+--replace_regex /'\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}'/'ts5'/
+--eval RESTORE test.t1 FROM RECYCLE_BIN WITH TIMESTAMP('$last_drop_time')
+
+select * from test.t1;
+--replace_column 3 # 4 # 5 #
+show recycle_bin;
+
+drop table test.t1;
+clear recycle_bin;
+
+set global txsql_recycle_bin_enabled = default;

--- a/sql/recycle_bin.cc
+++ b/sql/recycle_bin.cc
@@ -563,38 +563,23 @@ bool Recycle_bin_persistor::find_tables_before_time(
     dd::Raw_record record{table};
 
     if (record.store(FIELD_ORIGIN_SCHEMA, dd::String_type(db_name)) ||
-        record.store(FIELD_ORIGIN_TABLE, dd::String_type(table_name)))
-      return true;
+        record.store(FIELD_ORIGIN_TABLE, dd::String_type(table_name))) {
+      err = -1;
+      goto end;
+    }
 
-    uchar user_key[MAX_KEY_LENGTH];
-    uint key_no = KEY_SCHEMA_TABLE;
-    KEY *key_info = table->key_info + key_no;
-    key_copy(user_key, table->record[0], key_info, key_info->key_length);
-
-    if ((err = table->file->ha_index_init(key_no, true))) {
+    if ((err = table->file->ha_index_init(KEY_DROP_TIME, true))) {
       table->file->print_error(err, MYF(0));
       goto end;
     }
 
-    my_timeval oldest_table = {INT64_MAX, INT64_MAX};
-    for ((err = table->file->ha_index_read_map(
-              table->record[0], user_key,
-              make_prev_keypart_map(key_parts[KEY_SCHEMA_TABLE]),
-              HA_READ_PREFIX_LAST));
-         !err;
-         (err = table->file->ha_index_prev(table->record[0]))) {
+    for ((err = table->file->ha_index_first(table->record[0])); !err;
+        (err = table->file->ha_index_next(table->record[0]))) {
       if (!match_schema_table_key(record, db_name, table_name)) continue;
       my_timeval now = record.read_timestamp(FIELD_DROP_TIME);
       if (before_time && now.m_tv_sec >= before_time) break;
-
-      if (!all && (now.m_tv_sec < oldest_table.m_tv_sec ||
-                   (now.m_tv_sec == oldest_table.m_tv_sec &&
-                    now.m_tv_usec < oldest_table.m_tv_usec))) {
-        tables.clear();
-        tables.push_back(record.read_str(FIELD_TABLE_NAME).c_str());
-      } else if (all) {
-        tables.push_back(record.read_str(FIELD_TABLE_NAME).c_str());
-      }
+      tables.push_back(record.read_str(FIELD_TABLE_NAME).c_str());
+      if (!all) break;
     }
     table->file->ha_index_end();
     if (err == HA_ERR_END_OF_FILE || err == HA_ERR_KEY_NOT_FOUND) err = 0;


### PR DESCRIPTION
… drop_time

Problem:
The CLEAR RECYCLE_BIN ... BEFORE TIMESTAMP command used an incorrect time comparison logic when filtering recycle bin records. The index scan on KEY_DROP_TIME did not properly filter records by drop_time, causing the CLEAR operation to fail to find matching records even when valid entries existed with drop_time earlier than the specified timestamp.

Solution:
Fix the find_tables_before_time() function to correctly compare drop_time against the user-specified before_time. Records with drop_time strictly less than before_time are now properly selected for purging. When ALL is not specified, only the oldest record (first match in drop_time order) is cleared; when ALL is specified, all matching records are cleared. Added test case recycle_bin_clear.test to verify the behavior