### PR TITLE
Bug#36487526 MDS Crash in X plugin protocol encoder

### DIFF
--- a/mysql-test/r/subquery_scalar_to_derived_correlated.result
+++ b/mysql-test/r/subquery_scalar_to_derived_correlated.result
@@ -975,4 +975,20 @@ Note	1276	Field or reference 'test.alias1.b' of SELECT #3 was resolved in SELECT
 Note	1276	Field or reference 'test.alias1.b' of SELECT #2 was resolved in SELECT #1
 Note	1003	/* select#1 */ select `test`.`alias1`.`b` AS `b` from `test`.`t1` `alias1` where (0 <> (/* select#2 */ select count(`test`.`t1`.`b`) from `test`.`t1` where (exists(/* select#3 */ select sum(`test`.`t1`.`b`) from `test`.`t1` where (0 <> `test`.`alias1`.`b`)) and (0 <> `test`.`alias1`.`b`))))
 DROP TABLE t1;
+#
+# Bug#36487526 MDS Crash in X plugin protocol encoder
+#
+# Simplified repro
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+SELECT COUNT(*)+(SELECT COUNT(*) FROM t1 WHERE t1.f1 = t2.f1) FROM t1 AS t2 GROUP BY f2;
+COUNT(*)+(SELECT COUNT(*) FROM t1 WHERE t1.f1 = t2.f1)
+EXPLAIN SELECT COUNT(*)+(SELECT COUNT(*) FROM t1 WHERE t1.f1 = t2.f1) FROM t1 AS t2 GROUP BY f2;
+id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
+1	PRIMARY	t2	NULL	ALL	NULL	NULL	NULL	NULL	1	100.00	Using temporary
+1	PRIMARY	<derived2>	NULL	ref	<auto_key0>	<auto_key0>	5	test.t2.f1	2	100.00	NULL
+2	DERIVED	t1	NULL	ALL	NULL	NULL	NULL	NULL	1	100.00	Using temporary
+Warnings:
+Note	1276	Field or reference 'test.t2.f1' of SELECT #2 was resolved in SELECT #1
+Note	1003	/* select#1 */ select (count(0) + coalesce(`derived_1_2`.`COUNT(*)`,0)) AS `COUNT(*)+(SELECT COUNT(*) FROM t1 WHERE t1.f1 = t2.f1)` from `test`.`t1` `t2` left join (/* select#2 */ select count(0) AS `COUNT(*)`,`test`.`t1`.`f1` AS `f1` from `test`.`t1` group by `test`.`t1`.`f1`) `derived_1_2` on((`derived_1_2`.`f1` = `test`.`t2`.`f1`)) where true group by `test`.`t2`.`f2`
+DROP TABLE t1;
 SET optimizer_switch = 'subquery_to_derived=default';

--- a/mysql-test/t/subquery_scalar_to_derived_correlated.test
+++ b/mysql-test/t/subquery_scalar_to_derived_correlated.test
@@ -715,6 +715,20 @@ eval EXPLAIN $query;
 
 DROP TABLE t1;
 
+--echo #
+--echo # Bug#36487526 MDS Crash in X plugin protocol encoder
+--echo #
+
+--echo # Simplified repro
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+let $query=
+SELECT COUNT(*)+(SELECT COUNT(*) FROM t1 WHERE t1.f1 = t2.f1) FROM t1 AS t2 GROUP BY f2;
+
+eval $query;
+eval EXPLAIN $query;
+
+DROP TABLE t1;
+
 SET optimizer_switch = 'subquery_to_derived=default';
 # Local Variables:
 # mode: sql

--- a/sql/item_subselect.cc
+++ b/sql/item_subselect.cc
@@ -2825,6 +2825,7 @@ Item *Item_singlerow_subselect::replace_scalar_subquery(uchar *arg) {
     Item *coa = new (current_thd->mem_root) Item_func_coalesce(result, zero);
     if (coa == nullptr) return nullptr;
     if (coa->fix_fields(current_thd, &coa)) return nullptr;
+    coa->hidden = result->hidden;
     result = coa;
   }
   return result;


### PR DESCRIPTION
Also closes duplicate Bug#36505461.

When trying to return metadata, the code sees a visible column (the first in the result set) which has no item_name set, which is inconsistent; all visible items in the select list have item names set.

The first column in the result set in this case (marked as visible) is the COALESCE expression generated by the transform. This should have been marked as a hidden item.

The underlying issue is that when the COALESCE is wrapped around the expression in Item_singlerow_subselect::replace_scalar_subquery, the new COALESCE doesn't inherit the hidden status of the expression it is wrapping.

Solution: make COALESCE inherit the hidden status.
Change-Id: Ia44e605db378bfc46821af5cdfefdf90999033ab