### PR TITLE
[Cherry-pick] Bug#25579578 post-push fix: 32-bit build type mismatch in dict0dict.cc

### DIFF
--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -2030,7 +2030,7 @@ ulint dict_index_node_ptr_max_size(const dict_index_t *index) /*!< in: index */
   ulint comp;
   ulint i;
   /* maximum possible storage size of a record */
-  ulint rec_max_size;
+  size_t rec_max_size;
 
   if (dict_index_is_ibuf(index)) {
     /* cannot estimate accurately */


### PR DESCRIPTION
## What does this PR do?

Cherry-picks the upstream MySQL post-push fix for **Bug#25579578** to
resolve a 32-bit build failure in `dict0dict.cc`.

Closes #75

## Upstream reference

- MySQL upstream commit: [`568e41fd6f59d2756e8ef8d4fed7bdfb02506216`](https://github.com/mysql/mysql-server/commit/568e41fd6f59d2756e8ef8d4fed7bdfb02506216)
- Bug title: *Bug#25579578 INNODB: FAILING ASSERTION: !FIELD->PREFIX_LEN || FIELD->FIXED_LEN == FIELD->PREF — post push fix*

## Root cause

`rec_max_size` was declared as `ulint`, but `get_field_max_size()` expects
`size_t`. On 64-bit platforms both resolve to `unsigned long`, so the
mismatch is invisible. On 32-bit platforms `size_t` is `unsigned int`
while `ulint` remains `unsigned long`, causing a build failure.

## Fix

Change `rec_max_size` from `ulint` to `size_t` in
`storage/innobase/dict/dict0dict.cc`.

## Changes

- `storage/innobase/dict/dict0dict.cc` — 1 line type change.

## Test plan

- 64-bit build: behavior unchanged (both types are `unsigned long`).
- 32-bit build: type now matches the callee's parameter — build succeeds.

## Branch

- Source: `WayneChange/TXSQL:bugfix/cherry-pick-bug25579578-post-push-fix`
- Target: `OpenTenBase/TXSQL:8.0.30`
