### PR TITLE
Bugfix#72: SEGV (Item_subselect::print() at sql/item_subselect.cc:833…

### DIFF
--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -4391,7 +4391,6 @@ bool find_order_in_list(THD *thd, Ref_item_array ref_item_array,
       if ((*order->item)->real_item() != (*select_item)->real_item()) {
         Item::Cleanup_after_removal_context ctx(
             thd->lex->current_query_block());
-
         (*order->item)
             ->walk(&Item::clean_up_after_removal, enum_walk::SUBQUERY_POSTFIX,
                    pointer_cast<uchar *>(&ctx));
@@ -4527,6 +4526,20 @@ bool setup_order(THD *thd, Ref_item_array ref_item_array, TABLE_LIST *tables,
   const bool is_aggregated = select->is_grouped();
 
   for (uint number = 1; order; order = order->next, number++) {
+    Item *order_item = *order->item;
+    if (order_item->fixed && !order_item->const_item()) {
+      // If a non constant expression in order by is already
+      // resolved, it must have been merged from a derived table.
+      // So, we do not need to re-resolve in this query block. Add
+      // a hidden item instead.
+      uint size = fields->size();
+      order_item->hidden = true;
+      order->in_field_list = false;
+      fields->push_front(order_item);
+      ref_item_array[size] = order_item;
+      continue;
+    }
+
     if (find_order_in_list(thd, ref_item_array, tables, order, fields, false,
                            false))
       return true;


### PR DESCRIPTION
…) reported by ASan

cherry-pick from c9908eb639c2566f6519c2a370e68eb13edcf139 by Chaithra Gopalareddy

For this problem to happen, it needs several conditions to be met:
1. A mergeable derived table having a subquery in select list which is referenced by ORDER BY through an alias. This makes the ORDER BY reference the select expression when it gets resolved.
2. Needs to have a subquery with the same name in the query block where the derived table gets merged.
3. Needs to have window function referencing the subquery through an alias in PARTITION BY or ORDER BY clause. This makes it take a special path while resolving the ordering item to point to the view reference (from the merged derived table) than the one in the select list.

When the derived table having the order by referencing the subquery in select expression gets merged, order by is moved to the outer query block. This makes another call to resolve the order by item. This time, it cleans up the order by item since it resolves against the select list again. Later, window function's partition by clause resolves against the view reference pointing to the subquery which was deleted previously leading to problems later during optimization.

Solution is to not do the resolving again for a merged order by expression. We now have a check for a non constant expression that is already resolved and for such a order by expression, we just add a hidden element to the merged query block instead of re-resolving it.

Change-Id: Idf33bca4ae1db29bfc5fcdc7e768e3ca77109441