### PR TITLE
Port bug Bug#34890862 Bug#35410465 Bug#34616553

### DIFF
--- a/mysql-test/r/derived.pq
+++ b/mysql-test/r/derived.pq
@@ -79,11 +79,11 @@ a	b
 select * from (select * from t1 union all select * from t1) a;
 a	b
 1	a
+2	b
+3	c
+3	c
 1	a
 2	b
-2	b
-3	c
-3	c
 3	c
 3	c
 select * from (select * from t1 union all select * from t1 limit 2) a;
@@ -670,8 +670,8 @@ f1	f11
 2	2
 3	3
 5	5
-7	7
 9	9
+7	7
 explain for multitable derived
 EXPLAIN SELECT * FROM (SELECT * FROM t1 JOIN t2 ON f1=f2) tt;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
@@ -821,8 +821,8 @@ f1	f11
 2	2
 3	3
 5	5
-7	7
 9	9
+7	7
 explain showing created indexes and late materialization
 FLUSH STATUS;
 EXPLAIN
@@ -1070,42 +1070,6 @@ f1	f11	f1	f11	f1	f11
 5	5	5	5	5	5
 5	5	5	5	5	5
 5	5	5	5	5	5
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
-7	7	7	7	7	7
 9	9	9	9	9	9
 9	9	9	9	9	9
 9	9	9	9	9	9
@@ -1142,6 +1106,42 @@ f1	f11	f1	f11	f1	f11
 9	9	9	9	9	9
 9	9	9	9	9	9
 9	9	9	9	9	9
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
+7	7	7	7	7	7
 SHOW STATUS LIKE 'Handler_read%';
 Variable_name	Value
 Handler_read_first	0
@@ -1333,8 +1333,8 @@ Warnings:
 Note	1003	/* select#1 */ select `test`.`t2`.`f2` AS `f2`,`test`.`t2`.`f22` AS `f22` from `test`.`t2` where ((`test`.`t2`.`f2` < 7) and (`test`.`t2`.`f2` in (2,3)))
 SELECT * FROM (SELECT * FROM v6) tt;
 f2	f22
-2	2
 3	3
+2	2
 materialized view in a merged view in a materialized derived
 CREATE VIEW v7 AS SELECT * FROM v1;
 EXPLAIN SELECT * FROM (SELECT * FROM v7 GROUP BY 1) tt;
@@ -2411,8 +2411,8 @@ FROM t1 JOIN (SELECT a, b, @c:= a+b FROM t2) AS dt ON t1.a=dt.a;
 a	b	a	b	@c:= a+b
 1	10	1	100	101
 2	20	2	200	202
-Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Consider alternatives: 'SET variable=expression, ...', or 'SELECT expression(s) INTO variables(s)'.
 Warnings:
+Warning	1287	Setting user variables within expressions is deprecated and will be removed in a future release. Consider alternatives: 'SET variable=expression, ...', or 'SELECT expression(s) INTO variables(s)'.
 explain SELECT *
 FROM t1 JOIN (SELECT a, b, @c:= a+b FROM t2) AS dt ON t1.a=dt.a;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
@@ -3660,14 +3660,14 @@ ON t2.c2k = t1.c1k
 RIGHT JOIN t2 AS alias2
 ON alias2.c2n = alias1.dt_field;
 field1
-cc
-cc
-cc
-cc
 ff
-kk
-rr
 tt
+cc
+cc
+cc
+cc
+rr
+kk
 prepare s from 'SELECT alias1.dt_field AS field1
 FROM (SELECT t2.c2n AS dt_field
 FROM t1 RIGHT JOIN t2
@@ -3694,14 +3694,14 @@ ON t2.c2k = t1.c1k
 RIGHT JOIN t2 AS alias2
 ON alias2.c2n = alias1.dt_field;
 field1
-cc
-cc
-cc
-cc
 ff
-kk
-rr
 tt
+cc
+cc
+cc
+cc
+rr
+kk
 prepare s from 'SELECT alias1.dt_field AS field1
 FROM (SELECT t2.c2n AS dt_field
 FROM t2 LEFT JOIN t1
@@ -3725,27 +3725,27 @@ FROM vl AS alias1
 RIGHT JOIN t2 AS alias2
 ON alias2.c2n = alias1.v_field;
 field1
-cc
-cc
-cc
-cc
 ff
-kk
-rr
 tt
+cc
+cc
+cc
+cc
+rr
+kk
 SELECT alias1.v_field AS field1
 FROM vr AS alias1
 RIGHT JOIN t2 AS alias2
 ON alias2.c2n = alias1.v_field;
 field1
-cc
-cc
-cc
-cc
 ff
-kk
-rr
 tt
+cc
+cc
+cc
+cc
+rr
+kk
 SELECT alias1.dt_field AS field1
 FROM (SELECT t2.c2n AS dt_field
 FROM t1 RIGHT JOIN
@@ -3756,14 +3756,14 @@ ON t2.c2k = t1.c1k
 RIGHT JOIN t2 AS alias2
 ON alias2.c2n = alias1.dt_field;
 field1
-cc
-cc
-cc
-cc
 ff
-kk
-rr
 tt
+cc
+cc
+cc
+cc
+rr
+kk
 SELECT alias1.dt_field AS field1
 FROM (SELECT t2.c2n AS dt_field
 FROM t1 RIGHT JOIN
@@ -3774,14 +3774,14 @@ ON t2.c2k = t1.c1k
 RIGHT JOIN t2 AS alias2
 ON alias2.c2n = alias1.dt_field;
 field1
-cc
-cc
-cc
-cc
 ff
-kk
-rr
 tt
+cc
+cc
+cc
+cc
+rr
+kk
 DROP VIEW vl, vr;
 DROP TABLE t1, t2, `empty`;
 # Bug#22239474: Unexpected error 1093 on nested subquery for update
@@ -4072,7 +4072,7 @@ id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered
 1	SIMPLE	t1	NULL	system	NULL	NULL	NULL	NULL	1	100.00	NULL
 Warnings:
 Note	1249	Select 3 was reduced during optimization
-Note	1003	/* select#1 */ select 1 AS `alias1`,`alias1` AS `alias2` from dual
+Note	1003	/* select#1 */ select 1 AS `alias1`,1 AS `alias2` from dual
 SELECT *
 FROM (SELECT (1) alias1,
 (SELECT alias1) alias2
@@ -4100,7 +4100,7 @@ id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered
 1	SIMPLE	t1	NULL	system	NULL	NULL	NULL	NULL	1	100.00	NULL
 Warnings:
 Note	1249	Select 3 was reduced during optimization
-Note	1003	/* select#1 */ select `alias1` AS `alias2` from dual
+Note	1003	/* select#1 */ select 1 AS `alias2` from dual
 SELECT alias2
 FROM (SELECT (1) alias1,
 (SELECT alias1) alias2
@@ -4613,15 +4613,15 @@ WHERE dayofyear(1) AND max(1)
 GROUP BY a
 ) FROM t1;
 (
-)
-) d1
-1
-GROUP BY a
 SELECT 1 FROM (
 SELECT avg(1) FROM t1
 WHERE dayofyear(1) AND max(1)
-Warning	1292	Incorrect datetime value: '1'
+) d1
+GROUP BY a
+)
+1
 Warnings:
+Warning	1292	Incorrect datetime value: '1'
 SET sql_mode=DEFAULT;
 DROP TABLE t1;
 #
@@ -4668,3 +4668,55 @@ a	(SELECT MIN(c) FROM cte AS cte2 WHERE t2.d = cte2.b)
 2	60
 3	60
 DROP TABLE t1, t2;
+#
+# Bug#35410465: Subquery ORDER BY is ignored
+#
+CREATE TABLE t1 (f1 LONGTEXT, f2 INTEGER);
+INSERT INTO t1 VALUES (NULL, NULL), (1,2);
+SELECT f1
+FROM (SELECT *
+FROM (SELECT t1.*
+FROM t1 LEFT JOIN t1 AS t2
+ON (t1.f1 = t2.f1)) AS dt1 ORDER BY f1 asc) AS dt2;
+f1
+NULL
+1
+DROP TABLE t1;
+CREATE TABLE t1
+(a LONGTEXT,
+b BIGINT DEFAULT NULL,
+c DOUBLE DEFAULT NULL,
+d DATETIME DEFAULT NULL)
+ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+INSERT INTO t1 VALUES
+(NULL,NULL,NULL,NULL),('Cat1',0,0.5,'2013-06-10 11:10:10'),
+('Cat2',1,1.5,'2013-06-11 12:11:11'),('Cat1',2,2.5,'2013-06-12 13:12:12'),
+('Cat2',3,3.5,'2013-06-13 14:13:13'),('Cat1',4,4.5,'2013-06-14 15:14:14'),
+('Cat2',5,5.5,'2013-06-15 16:15:15'),('Cat1',6,6.5,'2013-06-16 17:16:16'),
+('Cat2',7,7.5,'2013-06-17 18:17:17'),('Cat1',8,8.5,'2013-06-18 19:18:18');
+SELECT a, b
+FROM (SELECT a, b, count1, count2
+FROM (SELECT dt3.a, dt3.b, dt3.count1, count2
+FROM (SELECT dt1.a, dt1.b, count1
+FROM (SELECT a, b
+FROM (SELECT a, b FROM t1) AS dt GROUP BY a, b) AS dt1
+LEFT JOIN
+(SELECT a, COUNT(*) AS count1 FROM t1 GROUP BY a) AS dt2
+ON (dt2.a = dt1.a)) AS dt3
+LEFT JOIN
+(SELECT a, COUNT(*) AS count2
+FROM (SELECT a FROM t1) AS dt5 GROUP BY a) AS dt4
+ON (dt3.a = dt4.a)) AS dt5
+ORDER BY count1 desc, a, count2 desc, b) AS dt6;
+a	b
+Cat1	0
+Cat1	2
+Cat1	4
+Cat1	6
+Cat1	8
+Cat2	1
+Cat2	3
+Cat2	5
+Cat2	7
+NULL	NULL
+DROP TABLE t1;

--- a/mysql-test/r/derived.result
+++ b/mysql-test/r/derived.result
@@ -4639,3 +4639,55 @@ a	(SELECT MIN(c) FROM cte AS cte2 WHERE t2.d = cte2.b)
 2	60
 3	60
 DROP TABLE t1, t2;
+#
+# Bug#35410465: Subquery ORDER BY is ignored
+#
+CREATE TABLE t1 (f1 LONGTEXT, f2 INTEGER);
+INSERT INTO t1 VALUES (NULL, NULL), (1,2);
+SELECT f1
+FROM (SELECT *
+FROM (SELECT t1.*
+FROM t1 LEFT JOIN t1 AS t2
+ON (t1.f1 = t2.f1)) AS dt1 ORDER BY f1 asc) AS dt2;
+f1
+NULL
+1
+DROP TABLE t1;
+CREATE TABLE t1
+(a LONGTEXT,
+b BIGINT DEFAULT NULL,
+c DOUBLE DEFAULT NULL,
+d DATETIME DEFAULT NULL)
+ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+INSERT INTO t1 VALUES
+(NULL,NULL,NULL,NULL),('Cat1',0,0.5,'2013-06-10 11:10:10'),
+('Cat2',1,1.5,'2013-06-11 12:11:11'),('Cat1',2,2.5,'2013-06-12 13:12:12'),
+('Cat2',3,3.5,'2013-06-13 14:13:13'),('Cat1',4,4.5,'2013-06-14 15:14:14'),
+('Cat2',5,5.5,'2013-06-15 16:15:15'),('Cat1',6,6.5,'2013-06-16 17:16:16'),
+('Cat2',7,7.5,'2013-06-17 18:17:17'),('Cat1',8,8.5,'2013-06-18 19:18:18');
+SELECT a, b
+FROM (SELECT a, b, count1, count2
+FROM (SELECT dt3.a, dt3.b, dt3.count1, count2
+FROM (SELECT dt1.a, dt1.b, count1
+FROM (SELECT a, b
+FROM (SELECT a, b FROM t1) AS dt GROUP BY a, b) AS dt1
+LEFT JOIN
+(SELECT a, COUNT(*) AS count1 FROM t1 GROUP BY a) AS dt2
+ON (dt2.a = dt1.a)) AS dt3
+LEFT JOIN
+(SELECT a, COUNT(*) AS count2
+FROM (SELECT a FROM t1) AS dt5 GROUP BY a) AS dt4
+ON (dt3.a = dt4.a)) AS dt5
+ORDER BY count1 desc, a, count2 desc, b) AS dt6;
+a	b
+Cat1	0
+Cat1	2
+Cat1	4
+Cat1	6
+Cat1	8
+Cat2	1
+Cat2	3
+Cat2	5
+Cat2	7
+NULL	NULL
+DROP TABLE t1;

--- a/mysql-test/r/subquery_bugs.pq
+++ b/mysql-test/r/subquery_bugs.pq
@@ -162,8 +162,8 @@ WHERE t2.k = CONCAT(t1.k, 'X')) = 'XXX',
 SUM(k)
 FROM t1;
 (SELECT 'X' FROM t2
-NULL	NULL
 WHERE t2.k = CONCAT(t1.k, 'X')) = 'XXX'	SUM(k)
+NULL	NULL
 EXPLAIN SELECT SUM(k), k
 FROM t1
 HAVING (SELECT 'X' FROM t2
@@ -202,9 +202,9 @@ WHERE t2.k = CONCAT(t1.k, 'X')
 AND SUM(t1.k)) = 'XXX'
 FROM t1;
 (SELECT 'X' FROM t2
+WHERE t2.k = CONCAT(t1.k, 'X')
 AND SUM(t1.k)) = 'XXX'
 NULL
-WHERE t2.k = CONCAT(t1.k, 'X')
 SET SQL_MODE=ONLY_FULL_GROUP_BY;
 EXPLAIN SELECT (SELECT 'X' FROM t2
 WHERE t2.k = CONCAT(t1.k, 'X')) = 'XXX'
@@ -276,8 +276,8 @@ WHERE t2.k = CONCAT(t1.k, 'X')) = 'XXX',
 SUM(k)
 FROM t1;
 (SELECT 'X' FROM t2
-NULL	NULL
 WHERE t2.k = CONCAT(t1.k, 'X')) = 'XXX'	SUM(k)
+NULL	NULL
 EXPLAIN SELECT SUM(k), k
 FROM t1
 HAVING (SELECT 'X' FROM t2
@@ -316,9 +316,9 @@ WHERE t2.k = CONCAT(t1.k, 'X')
 AND SUM(t1.k)) = 'XXX'
 FROM t1;
 (SELECT 'X' FROM t2
+WHERE t2.k = CONCAT(t1.k, 'X')
 AND SUM(t1.k)) = 'XXX'
 NULL
-WHERE t2.k = CONCAT(t1.k, 'X')
 SET SQL_MODE=DEFAULT;
 EXPLAIN SELECT (SELECT 'X' FROM t2
 WHERE t2.k = CONCAT(t1.k, 'X')) = 'XXX'
@@ -526,11 +526,11 @@ FROM t1 AS alias1 RIGHT JOIN t1 AS alias2
 ON alias1.cv = alias2.cv
 );
 cv
-I
-Q
-W
 h
+Q
+I
 q
+W
 DROP TABLE t1;
 # Bug#28970261: Sig6 in decorrelate_equality()
 CREATE TABLE t1 (col_varchar_key varchar(1) DEFAULT NULL);
@@ -1179,12 +1179,12 @@ GROUP BY table_user.id
 ) AS d
 ) AS users FROM table_city;
 id	users
-1	1,2,3,4,5,6,7,8
 2	1,2,3,4,5
-3	2,5
-4	1,2,3,5,8
 5	NULL
+4	1,2,3,5,8
+3	2,5
 6	NULL
+1	1,2,3,4,5,6,7,8
 DROP TABLE table_city, table_user, table_city_user;
 #
 # Bug#30267889 ASSERTION `M_INDEX_CURSOR.IS_POSITIONED()' FAILED | TEMPTABLE::HANDLER::POSITION
@@ -1629,21 +1629,21 @@ ON 1 > 2
 );
 1=
 (
+SELECT 1 FROM
 (
+SELECT 1 FROM t
+LEFT JOIN
 (
+SELECT 1 FROM t
+WHERE NOT EXISTS
 (
-)
+SELECT 1 FROM t WINDOW w1 AS (PARTITION BY a)
 )
 ) AS x
-) AS z
-LEFT JOIN
-NULL
 ON 1 > 2
-SELECT 1 FROM
-SELECT 1 FROM t
-SELECT 1 FROM t
-SELECT 1 FROM t WINDOW w1 AS (PARTITION BY a)
-WHERE NOT EXISTS
+) AS z
+)
+NULL
 DROP TABLE t;
 # Bug#30899681 Mysqld got signal 11 at Item::walk() 
 CREATE TABLE t1 (
@@ -1770,12 +1770,12 @@ SELECT a FROM (SELECT 1) u
 )
 FROM t GROUP BY 1;
 (
-(
-)
-) z
-1
 SELECT 1 FROM
+(
 SELECT a FROM (SELECT 1) u
+) z
+)
+1
 DROP TABLE t;
 #
 # Bug #31530529: SERVER CRASH SEEN - (MY_PRINT_STACKTRACE(UNSIGNED CHAR CONST*, UNSIGNED LONG)
@@ -2147,16 +2147,16 @@ FROM t0
 )
 );
 c0
--1945919442
--543970881
--64596961
-1230052719
-1936
-1983
-321108437
 329053785
 NULL
+-543970881
 NULL
+-64596961
+1936
+1230052719
+1983
+-1945919442
+321108437
 NULL
 NULL
 NULL
@@ -2224,3 +2224,15 @@ vc1	vc2	vc3
 1	1	1
 DROP VIEW v1;
 DROP TABLE vt1, vt2, vt3, vt4, t1, t2;
+#
+# Bug#34890862: Mysql server crash : `item->hidden == hidden' in
+#               assert_consistent_hidden_flags
+#
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+SELECT *
+FROM (SELECT (SELECT SUM(t1.f1) FROM t1) AS subq
+FROM t1 AS t2
+WHERE t2.f1 IN (SELECT 1 FROM t1)
+ORDER BY t2.f2, subq) AS dt;
+subq
+DROP TABLE t1;

--- a/mysql-test/r/subquery_bugs.result
+++ b/mysql-test/r/subquery_bugs.result
@@ -2163,3 +2163,15 @@ vc1	vc2	vc3
 1	1	1
 DROP VIEW v1;
 DROP TABLE vt1, vt2, vt3, vt4, t1, t2;
+#
+# Bug#34890862: Mysql server crash : `item->hidden == hidden' in
+#               assert_consistent_hidden_flags
+#
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+SELECT *
+FROM (SELECT (SELECT SUM(t1.f1) FROM t1) AS subq
+FROM t1 AS t2
+WHERE t2.f1 IN (SELECT 1 FROM t1)
+ORDER BY t2.f2, subq) AS dt;
+subq
+DROP TABLE t1;

--- a/mysql-test/t/derived.test
+++ b/mysql-test/t/derived.test
@@ -3338,3 +3338,48 @@ FROM t2 LEFT JOIN cte AS cte1 ON t2.a = cte1.a
         LEFT JOIN t2 AS tx ON tx.e = cte1.c;
 
 DROP TABLE t1, t2;
+
+--echo #
+--echo # Bug#35410465: Subquery ORDER BY is ignored
+--echo #
+
+CREATE TABLE t1 (f1 LONGTEXT, f2 INTEGER);
+INSERT INTO t1 VALUES (NULL, NULL), (1,2);
+SELECT f1
+FROM (SELECT *
+      FROM (SELECT t1.*
+            FROM t1 LEFT JOIN t1 AS t2
+                 ON (t1.f1 = t2.f1)) AS dt1 ORDER BY f1 asc) AS dt2;
+DROP TABLE t1;
+
+# Original repro
+CREATE TABLE t1
+ (a LONGTEXT,
+  b BIGINT DEFAULT NULL,
+  c DOUBLE DEFAULT NULL,
+  d DATETIME DEFAULT NULL)
+ ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+INSERT INTO t1 VALUES
+(NULL,NULL,NULL,NULL),('Cat1',0,0.5,'2013-06-10 11:10:10'),
+('Cat2',1,1.5,'2013-06-11 12:11:11'),('Cat1',2,2.5,'2013-06-12 13:12:12'),
+('Cat2',3,3.5,'2013-06-13 14:13:13'),('Cat1',4,4.5,'2013-06-14 15:14:14'),
+('Cat2',5,5.5,'2013-06-15 16:15:15'),('Cat1',6,6.5,'2013-06-16 17:16:16'),
+('Cat2',7,7.5,'2013-06-17 18:17:17'),('Cat1',8,8.5,'2013-06-18 19:18:18');
+
+SELECT a, b
+FROM (SELECT a, b, count1, count2
+      FROM (SELECT dt3.a, dt3.b, dt3.count1, count2
+            FROM (SELECT dt1.a, dt1.b, count1
+                  FROM (SELECT a, b
+                        FROM (SELECT a, b FROM t1) AS dt GROUP BY a, b) AS dt1
+                       LEFT JOIN
+                       (SELECT a, COUNT(*) AS count1 FROM t1 GROUP BY a) AS dt2
+                       ON (dt2.a = dt1.a)) AS dt3
+                 LEFT JOIN
+                 (SELECT a, COUNT(*) AS count2
+                  FROM (SELECT a FROM t1) AS dt5 GROUP BY a) AS dt4
+                 ON (dt3.a = dt4.a)) AS dt5
+      ORDER BY count1 desc, a, count2 desc, b) AS dt6;
+
+DROP TABLE t1;

--- a/mysql-test/t/subquery_bugs.test
+++ b/mysql-test/t/subquery_bugs.test
@@ -1835,3 +1835,18 @@ WHERE (vc3 IN (SELECT c1 FROM t1 WHERE c2='01'))
 
 DROP VIEW v1;
 DROP TABLE vt1, vt2, vt3, vt4, t1, t2;
+
+--echo #
+--echo # Bug#34890862: Mysql server crash : `item->hidden == hidden' in
+--echo #               assert_consistent_hidden_flags
+--echo #
+
+CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
+
+SELECT *
+FROM (SELECT (SELECT SUM(t1.f1) FROM t1) AS subq
+      FROM t1 AS t2
+      WHERE t2.f1 IN (SELECT 1 FROM t1)
+      ORDER BY t2.f2, subq) AS dt;
+
+DROP TABLE t1;

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -4385,7 +4385,6 @@ bool find_order_in_list(THD *thd, Ref_item_array ref_item_array,
       if ((*order->item)->real_item() != (*select_item)->real_item()) {
         Item::Cleanup_after_removal_context ctx(
             thd->lex->current_query_block());
-
         (*order->item)
             ->walk(&Item::clean_up_after_removal, enum_walk::SUBQUERY_POSTFIX,
                    pointer_cast<uchar *>(&ctx));
@@ -4521,6 +4520,20 @@ bool setup_order(THD *thd, Ref_item_array ref_item_array, TABLE_LIST *tables,
   const bool is_aggregated = select->is_grouped();
 
   for (uint number = 1; order; order = order->next, number++) {
+    Item *order_item = *order->item;
+    if (order_item->fixed && !order_item->const_item()) {
+      // If a non constant expression in order by is already
+      // resolved, it must have been merged from a derived table.
+      // So, we do not need to re-resolve in this query block. Add
+      // a hidden item instead.
+      uint size = fields->size();
+      order_item->hidden = true;
+      order->in_field_list = false;
+      fields->push_front(order_item);
+      ref_item_array[size] = order_item;
+      continue;
+    }
+
     if (find_order_in_list(thd, ref_item_array, tables, order, fields, false,
                            false))
       return true;

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -4529,11 +4529,12 @@ bool setup_order(THD *thd, Ref_item_array ref_item_array, TABLE_LIST *tables,
       // Update with the correct ref item.
       uint counter = fields->size();
       for (uint i = 0; i < fields->size(); i++) {
-        if (order_item->eq(ref_item_array[i]->real_item(), false)) {
+        if (order_item->real_item()->eq(ref_item_array[i]->real_item(),
+                                        false)) {
           order->item = &ref_item_array[i];
           // Order by is now referencing select expression, so increment the
           // reference count for the select expression.
-          (*order->item)->increment_ref_count();
+          // (*order->item)->increment_ref_count();
           order->in_field_list = true;
           counter = i;
           break;
@@ -4545,6 +4546,7 @@ bool setup_order(THD *thd, Ref_item_array ref_item_array, TABLE_LIST *tables,
         fields->push_front(order_item);
         order_item->hidden = true;
         order->in_field_list = false;
+        order->item = &ref_item_array[counter];
       }
       continue;
     }

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -4525,12 +4525,27 @@ bool setup_order(THD *thd, Ref_item_array ref_item_array, TABLE_LIST *tables,
       // If a non constant expression in order by is already
       // resolved, it must have been merged from a derived table.
       // So, we do not need to re-resolve in this query block. Add
-      // a hidden item instead.
-      uint size = fields->size();
-      order_item->hidden = true;
-      order->in_field_list = false;
-      fields->push_front(order_item);
-      ref_item_array[size] = order_item;
+      // a hidden item if not present in the visible fields list.
+      // Update with the correct ref item.
+      uint counter = fields->size();
+      for (uint i = 0; i < fields->size(); i++) {
+        if (order_item->eq(ref_item_array[i]->real_item(), false)) {
+          order->item = &ref_item_array[i];
+          // Order by is now referencing select expression, so increment the
+          // reference count for the select expression.
+          (*order->item)->increment_ref_count();
+          order->in_field_list = true;
+          counter = i;
+          break;
+        }
+      }
+      if (counter == fields->size()) {
+        // Add as a hidden item.
+        ref_item_array[counter] = order_item;
+        fields->push_front(order_item);
+        order_item->hidden = true;
+        order->in_field_list = false;
+      }
       continue;
     }
 


### PR DESCRIPTION
Bug#34890862: Mysql server crash : `item->hidden == hidden' in assert_consistent_hidden_flags

This is regression from Bug#34616553. When deciding to not re-resolve a merged order by expression, the order by expression was always added as a hidden item. However if the order by expression is part of the visible fields list of the query block where the order by is merged, the view ref in the select expression would be marked visible where as the order by item which is also the referenced item by the select expression would be marked hidden. This leads to an assert later when it is detected that there is a mismatch in the hidden flag for the view ref and the underlying referenced item. Solution is to not add a hidden element when the order by item is found in the visible fields list of the query block where the order by is merged to.

Bug#35410465: Subquery ORDER BY is ignored

This is a regression from Bug#34890862. That fix made a change for already resolved ORDER BY items to not be re-resolved (it is usually the case when a derived table is merged). As part of the change, when comparing the order by items to the visible fields in the outer query block, it compared the order by item with the referenced item in the ref_item_array. For the case in bugpage, the order by item itself is a reference. This makes the comparison fail.
So we now compare the real_item() of the order by expression to the real_item() of the ref_item_array elements.
Also, when a hidden item is added, the original fix missed to set order->item to point to the correct ref array item like what is done in find_order_in_list().

Bug#34616553: SEGV (Item_subselect::print() at sql/item_subselect.cc:833) reported by ASan

The problem was introduced before version 8.0.22 and fixed in community version 8.0.33.
For this problem to happen, it needs several conditions to be met:

A mergeable derived table having a subquery in select list which is referenced by ORDER BY through an alias. This makes the ORDER BY reference the select expression when it gets resolved.
Needs to have a subquery with the same name in the query block where the derived table gets merged.
Needs to have window function referencing the subquery through an alias in PARTITION BY or ORDER BY clause. This makes it take a special path while resolving the ordering item to point to the view reference (from the merged derived table) than the one in the select list.
When the derived table having the order by referencing the subquery in select expression gets merged, order by is moved to the outer query block. This makes another call to resolve the order by item. This time, it cleans up the order by item since it resolves against the select list again. Later, window function's partition by clause resolves against the view reference pointing to the subquery which was deleted previously leading to problems later during optimization.
Solution is to not do the resolving again for a merged order by expression. We now have a check for a non constant expression that is already resolved and for such a order by expression, we just add a hidden element to the merged query block instead of re-resolving it.