### PR TITLE
[bugfix] data corruption after INSTANT ALTER TABLE with utf16le/utf16…

### DIFF
--- a/mysql-test/suite/innodb/r/instant_modify_character_set.pq
+++ b/mysql-test/suite/innodb/r/instant_modify_character_set.pq
@@ -1,0 +1,56 @@
+create table t1(id int not null primary key, c1 varchar(10)) default character set=latin1;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf8mb3;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=binary;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf8mb4;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=latin1;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=utf8mb3;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=binary;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=utf8mb4;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=latin1;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf8mb3;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=binary;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf8mb4;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=gbk;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf16le;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=gbk;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf16le;
+alter table t1 modify column c1 char(20),algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+drop table t1;

--- a/mysql-test/suite/innodb/r/instant_modify_character_set.result
+++ b/mysql-test/suite/innodb/r/instant_modify_character_set.result
@@ -1,0 +1,56 @@
+create table t1(id int not null primary key, c1 varchar(10)) default character set=latin1;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf8mb3;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=binary;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf8mb4;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=latin1;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=utf8mb3;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=binary;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=utf8mb4;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=latin1;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf8mb3;
+Warnings:
+Warning	1287	'utf8mb3' is deprecated and will be removed in a future release. Please use utf8mb4 instead
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=binary;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf8mb4;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=gbk;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf16le;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+create table t1(id int not null primary key, c1 char(10)) default character set=gbk;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+drop table t1;
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf16le;
+alter table t1 modify column c1 char(20),algorithm=instant;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+drop table t1;

--- a/mysql-test/suite/innodb/t/instant_modify_character_set-master.opt
+++ b/mysql-test/suite/innodb/t/instant_modify_character_set-master.opt
@@ -1,0 +1,2 @@
+--cdb_instant_modify_column_enabled=on
+--cdb_instant_modify_column_enabled=on

--- a/mysql-test/suite/innodb/t/instant_modify_character_set.test
+++ b/mysql-test/suite/innodb/t/instant_modify_character_set.test
@@ -1,0 +1,69 @@
+# varchar -> char
+create table t1(id int not null primary key, c1 varchar(10)) default character set=latin1;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf8mb3;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 varchar(10)) default character set=binary;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf8mb4;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;
+
+# char -> varchar
+create table t1(id int not null primary key, c1 char(10)) default character set=latin1;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 char(10)) default character set=utf8mb3;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 char(10)) default character set=binary;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 char(10)) default character set=utf8mb4;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+
+# binary -> varbinary
+create table t1(id int not null primary key, c1 binary(10)) default character set=latin1;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf8mb3;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 binary(10)) default character set=binary;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf8mb4;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+
+# other character sets should fail except binary
+create table t1(id int not null primary key, c1 binary(10)) default character set=gbk;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 binary(10)) default character set=utf16le;
+alter table t1 modify column c1 varbinary(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 char(10)) default character set=gbk;
+error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON;
+alter table t1 modify column c1 varchar(20),algorithm=instant;
+drop table t1;
+
+create table t1(id int not null primary key, c1 varchar(10)) default character set=utf16le;
+error ER_ALTER_OPERATION_NOT_SUPPORTED_REASON;
+alter table t1 modify column c1 char(20),algorithm=instant;
+drop table t1;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -11883,29 +11883,43 @@ static inline bool innobase_support_modify_instant(
           && field->key_type() != HA_KEYTYPE_LONGLONG) { /* bigint */
         return (false);
       }
-    } else if (old_field->real_type() == MYSQL_TYPE_VAR_STRING) {
-      if (field->real_type() != MYSQL_TYPE_VAR_STRING &&
-          field->real_type() != MYSQL_TYPE_VARCHAR
-          //&& field->type() != MYSQL_TYPE_BIT
-          && field->real_type() != MYSQL_TYPE_STRING) {
-        return (false);
-      }
-    } else if (old_field->real_type() == MYSQL_TYPE_VARCHAR) {
-      if (field->real_type() != MYSQL_TYPE_VAR_STRING &&
-          field->real_type() != MYSQL_TYPE_VARCHAR
-          //&& field->type() != MYSQL_TYPE_BIT
-          && field->real_type() != MYSQL_TYPE_STRING) {
-        return (false);
-      }
-    } else if (old_field->real_type() == MYSQL_TYPE_STRING) {
-      if (field->real_type() != MYSQL_TYPE_VAR_STRING &&
-          field->real_type() != MYSQL_TYPE_VARCHAR
-          //&& field->type() != MYSQL_TYPE_BIT
-          && field->real_type() != MYSQL_TYPE_STRING) {
-        return (false);
-      }
     } else {
-      return (false);
+      /* string type, supported character sets:
+        1. utf8mb3
+        2. utf8mb4
+        3. latin1
+        4. binary
+      */
+      const std::string_view csname(old_field->charset()->csname);
+      if (csname.compare("utf8mb4") != 0 && csname.compare("utf8mb3") != 0 &&
+          csname.compare("latin1") != 0 && csname.compare("binary") != 0 &&
+          csname.compare("utf8") != 0) {
+        return false;
+      }
+      if (old_field->real_type() == MYSQL_TYPE_VAR_STRING) {
+        if (field->real_type() != MYSQL_TYPE_VAR_STRING &&
+            field->real_type() != MYSQL_TYPE_VARCHAR
+            //&& field->type() != MYSQL_TYPE_BIT
+            && field->real_type() != MYSQL_TYPE_STRING) {
+          return (false);
+        }
+      } else if (old_field->real_type() == MYSQL_TYPE_VARCHAR) {
+        if (field->real_type() != MYSQL_TYPE_VAR_STRING &&
+            field->real_type() != MYSQL_TYPE_VARCHAR
+            //&& field->type() != MYSQL_TYPE_BIT
+            && field->real_type() != MYSQL_TYPE_STRING) {
+          return (false);
+        }
+      } else if (old_field->real_type() == MYSQL_TYPE_STRING) {
+        if (field->real_type() != MYSQL_TYPE_VAR_STRING &&
+            field->real_type() != MYSQL_TYPE_VARCHAR
+            //&& field->type() != MYSQL_TYPE_BIT
+            && field->real_type() != MYSQL_TYPE_STRING) {
+          return (false);
+        }
+      } else {
+        return (false);
+      }
     }
   }
   return (true);


### PR DESCRIPTION
[bugfix] data corruption after INSTANT ALTER TABLE with utf16le/utf16/utf32 character set

Problem:
When performing ALTER TABLE ... ALGORITHM=INSTANT to modify a column (e.g., CHAR to VARCHAR) on a table using utf16le character set, the existing data becomes silently corrupted — previously stored values gain unexpected trailing spaces because CHAR padding bytes in the utf16le encoding are misinterpreted as VARCHAR payload after the instant metadata change.

The root cause is in innobase_support_instant(), which only validates column type compatibility but does not check whether the character set is compatible with the INSTANT algorithm physical row format.

Solution:
Add a character set whitelist for instant modification. Only allow utf8mb4, utf8mb3, latin1, and binary. For any unsupported character set (utf16le, utf16, utf32, gbk, etc.), reject INSTANT algorithm and force fallback to COPY/INPLACE.

This fix is applied in handler0alter.cc, adding a charset validation check in the innobase_support_instant() function before the existing column type compatibility logic.

Fixes #70