### PR TITLE
[feature] issue#51 binlog page cache cleaning optimization

### DIFF
--- a/mysql-test/include/default_mysqld.cnf
+++ b/mysql-test/include/default_mysqld.cnf
@@ -74,3 +74,6 @@ innodb_fast_ahi_cleanup_num_entries_thres=0
 
 loose-innodb-i-s-cache-min-idle-us=0
 innodb_skip_dive_for_unique_key=off
+cdb_page_cache_cleaning_binlog=on
+cdb_page_cache_cleaning_window=1048576
+cdb_page_cache_cleaning_redo=on

--- a/mysql-test/include/search_pattern_not_in_file.inc
+++ b/mysql-test/include/search_pattern_not_in_file.inc
@@ -1,0 +1,26 @@
+# Purpose:
+#    Simple search with Perl for asserting that a pattern is not in some file.
+# 
+# Created: 2011-11-11 mleich
+# Modified: 2014-04-26 hvadodar
+# Modified: 2021-01-04 mortyzhou
+#
+
+perl;
+    use strict;
+    my $search_file=           $ENV{'SEARCH_FILE'}           or die "SEARCH_FILE not set";
+    my $search_pattern=        $ENV{'SEARCH_PATTERN'}        or die "SEARCH_PATTERN not set";
+    my $file_content=          "";
+    my $found=                  0;
+    open(FILE, "$search_file") or die("Unable to open '$search_file': $!\n");
+    while ( read(FILE, $file_content, 50000, 0) ) {
+          if ( $file_content =~ m{$search_pattern} ) {
+             $found= 1;
+             last;
+          }
+    }
+    close(FILE);
+    if ( ($found == 1) || ($file_content =~ m{$search_pattern}) ) {
+       die("# ERROR: The file '$search_file' contains the unexpected pattern  $search_pattern\n->$file_content<-\n");
+    }
+EOF

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -326,6 +326,13 @@ The following options may be given as the first argument:
  --cdb-optimize-ps-priv-check 
  This option is deprecated. Use txsql_simplify_priv_check
  instead.
+ --cdb-page-cache-cleaning-binlog
+ Enable page cache cleaning for binlog files
+ --cdb-page-cache-cleaning-redo
+ 5.7 Compatable Var: No effect in 8.0.30
+ --cdb-page-cache-cleaning-window[=#]
+ Cleaning window size for page cache in bytes. Default is
+ 16,777,216(16MB).
  --cdb-recycle-bin-db-not-visible 
  This option is deprecated. Use
  txsql_recycle_bin_db_not_visible instead.
@@ -356,6 +363,8 @@ The following options may be given as the first argument:
  replication channel.
  --cdb-skip-event-scheduler 
  Enable the event scheduler.Possible values are ON,OFF
+ --cdb-sql-mode-fixup-enabled
+ 5.7 Compatable Var: No effect in 8.0.30
  --cdb-sql-statistics 
  sql statistics switch.
  --cdb-sql-statistics-info-threshold=# 
@@ -2066,6 +2075,9 @@ cdb-optimize-large-trans-binlog FALSE
 cdb-optimize-large-trans-binlog-aver-affected-rows-threshold 10000
 cdb-optimize-large-trans-binlog-last-affected-rows-threshold 10000
 cdb-optimize-ps-priv-check FALSE
+cdb-page-cache-cleaning-binlog FALSE
+cdb-page-cache-cleaning-redo FALSE
+cdb-page-cache-cleaning-window 16777216
 cdb-recycle-bin-db-not-visible TRUE
 cdb-recycle-bin-enabled FALSE
 cdb-recycle-bin-retention 604800
@@ -2073,6 +2085,7 @@ cdb-recycle-scheduler-interval 0
 cdb-replica-host-detection TRUE
 cdb-role CDB_ROLE_UNKNOWN
 cdb-skip-event-scheduler FALSE
+cdb-sql-mode-fixup-enabled FALSE
 cdb-sql-statistics FALSE
 cdb-sql-statistics-info-threshold 10000
 character-set-client-handshake TRUE

--- a/mysql-test/r/page_cache_cleaning_binlog_no_slave.result
+++ b/mysql-test/r/page_cache_cleaning_binlog_no_slave.result
@@ -1,0 +1,36 @@
+create table t(id int primary key auto_increment, 
+v1 char(255) default "1", 
+v2 char(255) default "1", 
+v3 char(255) default "1", 
+v4 char(255) default "1");
+set @old_cdb_page_cache_cleaning_binlog = @@cdb_page_cache_cleaning_binlog;
+set global cdb_page_cache_cleaning_binlog = on;
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+flush logs;
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+set global cdb_page_cache_cleaning_binlog = off;
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+flush logs;
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+drop table t;
+set global cdb_page_cache_cleaning_binlog = @old_cdb_page_cache_cleaning_binlog;

--- a/mysql-test/r/page_cache_cleaning_binlog_with_slave.result
+++ b/mysql-test/r/page_cache_cleaning_binlog_with_slave.result
@@ -1,0 +1,64 @@
+include/rpl_init.inc [topology=1->2, 1->3]
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+Warnings:
+Note	####	Sending passwords in plain text without SSL/TLS is extremely insecure.
+Note	####	Storing MySQL user name or password information in the master info repository is not secure and is therefore not recommended. Please consider using the USER and PASSWORD connection options for START SLAVE; see the 'START SLAVE Syntax' in the MySQL Manual for more information.
+start replica;
+include/wait_for_slave_to_start.inc
+create table t(id int primary key auto_increment, 
+v1 char(255) default "1", 
+v2 char(255) default "1", 
+v3 char(255) default "1", 
+v4 char(255) default "1");
+set global cdb_page_cache_cleaning_binlog = on;
+set @old_cdb_page_cache_cleaning_binlog = @@cdb_page_cache_cleaning_binlog;
+include/wait_for_slave_param.inc [Seconds_Behind_Master]
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+flush logs;
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+flush logs;
+include/wait_for_slave_param.inc [Seconds_Behind_Master]
+SET GLOBAL DEBUG='+d,trigger_page_cache_cleanup_after_reading_a_binlog_file';
+start replica;
+include/wait_for_slave_to_start.inc
+include/wait_for_slave_param.inc [Seconds_Behind_Master]
+SET GLOBAL DEBUG='-d,trigger_page_cache_cleanup_after_reading_a_binlog_file';
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+set global cdb_page_cache_cleaning_binlog = off;
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+flush logs;
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+drop table t;
+set global cdb_page_cache_cleaning_binlog = @old_cdb_page_cache_cleaning_binlog;
+include/rpl_end.inc

--- a/mysql-test/suite/perfschema/r/relaylog.result
+++ b/mysql-test/suite/perfschema/r/relaylog.result
@@ -73,6 +73,7 @@ wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_done	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_flush_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_index	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_log	MANY
+wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_progress_tracker	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_xids	NONE
@@ -175,6 +176,7 @@ wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_done	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_flush_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_index	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_log	MANY
+wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_progress_tracker	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_sync_queue	MANY
 wait/synch/mutex/sql/MYSQL_BIN_LOG::LOCK_xids	MANY

--- a/mysql-test/suite/perfschema/r/threads_mysql.result
+++ b/mysql-test/suite/perfschema/r/threads_mysql.result
@@ -44,6 +44,16 @@ ORDER BY name
 unified_parent_thread_id	unified parent_thread_id
 role	NULL
 instrumented	YES
+name	thread/sql/os_page_cache_cleaning
+type	BACKGROUND
+processlist_user	NULL
+processlist_host	NULL
+processlist_db	NULL
+processlist_command	NULL
+processlist_info	NULL
+unified_parent_thread_id	unified parent_thread_id
+role	NULL
+instrumented	YES
 name	thread/sql/signal_handler
 type	BACKGROUND
 processlist_user	NULL
@@ -125,6 +135,7 @@ parent_thread_name	child_thread_name
 thread/sql/event_scheduler	thread/sql/event_worker
 thread/sql/main	thread/sql/compress_gtid_table
 thread/sql/main	thread/sql/one_connection
+thread/sql/main	thread/sql/os_page_cache_cleaning
 thread/sql/main	thread/sql/signal_handler
 thread/sql/main	thread/sql/sql_statistics
 thread/sql/one_connection	thread/sql/event_scheduler

--- a/mysql-test/suite/sysschema/r/pr_ps_setup_show_enabled.result
+++ b/mysql-test/suite/sysschema/r/pr_ps_setup_show_enabled.result
@@ -243,6 +243,7 @@ root@localhost	FOREGROUND
 sql/compress_gtid_table	FOREGROUND
 sql/event_scheduler	FOREGROUND
 sql/main	BACKGROUND
+sql/os_page_cache_cleaning	BACKGROUND
 sql/sql_statistics	BACKGROUND
 threadpool/timer_thread	BACKGROUND
 CALL sys.ps_setup_show_enabled(TRUE, TRUE);
@@ -298,6 +299,7 @@ root@localhost	FOREGROUND
 sql/compress_gtid_table	FOREGROUND
 sql/event_scheduler	FOREGROUND
 sql/main	BACKGROUND
+sql/os_page_cache_cleaning	BACKGROUND
 sql/sql_statistics	BACKGROUND
 threadpool/timer_thread	BACKGROUND
 enabled_instruments	timed

--- a/mysql-test/t/page_cache_cleaning_binlog_no_slave-master.opt
+++ b/mysql-test/t/page_cache_cleaning_binlog_no_slave-master.opt
@@ -1,0 +1,3 @@
+--cdb_page_cache_cleaning_binlog=on
+--cdb_page_cache_cleaning_window=1048576
+--cdb_page_cache_cleaning_redo=off

--- a/mysql-test/t/page_cache_cleaning_binlog_no_slave.test
+++ b/mysql-test/t/page_cache_cleaning_binlog_no_slave.test
@@ -1,0 +1,83 @@
+--source include/have_log_bin.inc
+--source include/have_debug_sync.inc
+
+create table t(id int primary key auto_increment, 
+               v1 char(255) default "1", 
+               v2 char(255) default "1", 
+               v3 char(255) default "1", 
+               v4 char(255) default "1");
+
+connect (root_conn,127.0.0.1,root,,);
+connection root_conn;
+set @old_cdb_page_cache_cleaning_binlog = @@cdb_page_cache_cleaning_binlog;
+set global cdb_page_cache_cleaning_binlog = on;
+
+# case #1:  page cache cleaning functionality ON
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+
+# This rotates binlog which should trigger the cleanup
+flush logs;
+# Wait a while for the background thread to actually do the cleanup
+sleep 2;
+
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+
+--let SEARCH_PATTERN=progress_tracker: made progress
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=page cache cleaning without slaves
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=POSIX_FADV_DONTNEED
+--source include/search_pattern_in_file.inc
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+
+# First empty the error log
+--disable_result_log
+--exec echo > $SEARCH_FILE
+--enable_result_log
+
+# case #2: page cache cleaning functionality OFF
+set global cdb_page_cache_cleaning_binlog = off;
+--sleep 1
+
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+
+# This rotates binlog which should trigger the cleanup
+# However, we do not expect anything related to page cache 
+# cleaning in the debug log since the switch is off.
+flush logs;
+sleep 2;
+
+
+--let SEARCH_PATTERN=progress_tracker: made progress
+--source include/search_pattern_not_in_file.inc
+--let SEARCH_PATTERN=page cache cleaning without slaves
+--source include/search_pattern_not_in_file.inc
+--let SEARCH_PATTERN=POSIX_FADV_DONTNEED
+--source include/search_pattern_not_in_file.inc
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+
+drop table t;
+set global cdb_page_cache_cleaning_binlog = @old_cdb_page_cache_cleaning_binlog;
+disconnect root_conn;

--- a/mysql-test/t/page_cache_cleaning_binlog_with_slave-master.opt
+++ b/mysql-test/t/page_cache_cleaning_binlog_with_slave-master.opt
@@ -1,0 +1,3 @@
+--cdb_page_cache_cleaning_binlog=on
+--cdb_page_cache_cleaning_window=1048576
+--cdb_page_cache_cleaning_redo=off

--- a/mysql-test/t/page_cache_cleaning_binlog_with_slave.cnf
+++ b/mysql-test/t/page_cache_cleaning_binlog_with_slave.cnf
@@ -1,0 +1,12 @@
+!include ../include/default_my.cnf
+[mysqld.1]
+log-slave-updates
+[mysqld.2]
+log-slave-updates
+[mysqld.3]
+log-slave-updates
+
+[ENV]
+SERVER_MYPORT_1= @mysqld.1.port
+SERVER_MYPORT_2= @mysqld.2.port
+SERVER_MYPORT_3= @mysqld.3.port

--- a/mysql-test/t/page_cache_cleaning_binlog_with_slave.test
+++ b/mysql-test/t/page_cache_cleaning_binlog_with_slave.test
@@ -1,0 +1,170 @@
+--let $rpl_server_count= 3
+--let $rpl_skip_start_slave= 1
+--let $rpl_topology= 1->2, 1->3
+--source include/rpl_init.inc
+--source include/have_debug_sync.inc
+
+connection server_2; # master
+start replica;
+--source include/wait_for_slave_to_start.inc
+
+connection server_1;
+
+create table t(id int primary key auto_increment, 
+               v1 char(255) default "1", 
+               v2 char(255) default "1", 
+               v3 char(255) default "1", 
+               v4 char(255) default "1");
+
+connect (root_conn,127.0.0.1,root,,);
+connection root_conn;
+set global cdb_page_cache_cleaning_binlog = on;
+set @old_cdb_page_cache_cleaning_binlog = @@cdb_page_cache_cleaning_binlog;
+
+connection server_2;
+let $slave_param= Seconds_Behind_Master;
+let $slave_param_comparison= =; 
+let $slave_param_value= 0;
+source include/wait_for_slave_param.inc;
+
+connection server_1;
+
+# case #1:  page cache cleaning functionality ON
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+
+
+# This rotates binlog which should trigger the cleanup
+flush logs;
+# Wait a while for the background thread to actually do the cleanup
+sleep 2;
+
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+
+
+# This rotates binlog which should trigger the cleanup
+flush logs;
+# Wait a while for the background thread to actually do the cleanup
+sleep 2;
+
+connection server_2;
+let $slave_param= Seconds_Behind_Master;
+let $slave_param_comparison= =; 
+let $slave_param_value= 0;
+source include/wait_for_slave_param.inc;
+
+connection server_1;
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+
+--let SEARCH_PATTERN=progress_tracker: made progress
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=page cache cleaning with slaves
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=POSIX_FADV_DONTNEED
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=A cdb_page_cache_cleaning_window of
+--source include/search_pattern_in_file.inc
+
+
+
+# First empty the error log
+--disable_result_log
+--exec echo > $SEARCH_FILE
+--enable_result_log
+
+SET GLOBAL DEBUG='+d,trigger_page_cache_cleanup_after_reading_a_binlog_file';
+
+# Add a fresh slave.
+# This should trigger resetting the position of page cacge cleanup.
+# to the begining of the binlogs.
+connection server_3; # master
+start replica;
+--source include/wait_for_slave_to_start.inc
+
+let $slave_param= Seconds_Behind_Master;
+let $slave_param_comparison= =; 
+let $slave_param_value= 0;
+source include/wait_for_slave_param.inc;
+connection server_1;
+SET GLOBAL DEBUG='-d,trigger_page_cache_cleanup_after_reading_a_binlog_file';
+
+# Wait a while for the background thread to actually do the cleanup
+sleep 2;
+
+--let SEARCH_PATTERN=new dump thread read before the
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=progress_tracker: made progress
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=page cache cleaning with slaves
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=POSIX_FADV_DONTNEED
+--source include/search_pattern_in_file.inc
+--let SEARCH_PATTERN=A cdb_page_cache_cleaning_window of
+--source include/search_pattern_in_file.inc
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+
+
+# First empty the error log
+--disable_result_log
+--exec echo > $SEARCH_FILE
+--enable_result_log
+
+# case #2: page cache cleaning functionality OFF
+connection server_1;
+connection root_conn;
+set global cdb_page_cache_cleaning_binlog = off;
+connection server_1;
+--sleep 1
+
+SET GLOBAL DEBUG='+d,page_cache_cleaning_test';
+
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+insert into t(v1) values("1");
+
+# This rotates binlog which should trigger the cleanup
+# However, we do not expect anything related to page cache 
+# cleaning in the error log since the switch is off.
+flush logs;
+sleep 2;
+
+--let SEARCH_PATTERN=progress_tracker: made progress
+--source include/search_pattern_not_in_file.inc
+--let SEARCH_PATTERN=page cache cleaning with slaves
+--source include/search_pattern_not_in_file.inc
+--let SEARCH_PATTERN=POSIX_FADV_DONTNEED
+--source include/search_pattern_not_in_file.inc
+SET GLOBAL DEBUG='-d,page_cache_cleaning_test';
+
+
+# cleanup
+drop table t;
+connection root_conn;
+set global cdb_page_cache_cleaning_binlog = @old_cdb_page_cache_cleaning_binlog;
+--source include/rpl_end.inc

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -503,6 +503,7 @@ SET(SQL_SHARED_SOURCES
   opt_sum.cc
   opt_trace.cc
   opt_trace2server.cc
+  os_page_cache.cc
   pack_rows.cc
   parse_file.cc
   parse_tree_handler.cc

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -134,6 +134,8 @@
 #include "thr_lock.h"
 #include "sql/opt_statistics.h"
 
+#include "os_page_cache.h"
+#include "sql/rpl_source.h"
 extern bool txsql_slave_io_optimaze_write;
 extern ulonglong sqlasync_group_slave_relay_fsync ;
 
@@ -3606,7 +3608,8 @@ MYSQL_BIN_LOG::MYSQL_BIN_LOG(uint *sync_period, bool relay_log)
       previous_gtid_set_relaylog(nullptr),
       is_rotating_caused_by_incident(false),
       m_cur_bin_suffix(0),
-      m_cur_tmp_suffix(0) {
+      m_cur_tmp_suffix(0),
+      progress_tracker(this) {
   /*
     We don't want to initialize locks here as such initialization depends on
     safe_mutex (when using safe_mutex) which depends on MY_INIT(), which is
@@ -3650,7 +3653,7 @@ void MYSQL_BIN_LOG::cleanup() {
       Commit_stage_manager::get_instance().deinit();
     }
   }
-
+  progress_tracker.cleanup();
   delete m_binlog_file;
   m_binlog_file = nullptr;
 }
@@ -3676,6 +3679,7 @@ void MYSQL_BIN_LOG::init_pthread_objects() {
         m_key_LOCK_flush_queue, m_key_LOCK_sync_queue, m_key_LOCK_commit_queue,
         m_key_LOCK_done, m_key_COND_done, m_key_COND_flush_queue);
   }
+  progress_tracker.init();
 }
 
 void MYSQL_BIN_LOG::binlog_flush(ordered_commit_flush_thread *manager)
@@ -5351,6 +5355,7 @@ bool MYSQL_BIN_LOG::open_binlog(
   m_dependency_tracker.rotate();
 
   close_purge_index_file();
+  progress_tracker.update_active_file(log_file_name);
 
   update_binlog_end_pos();
   return false;
@@ -5801,6 +5806,7 @@ int MYSQL_BIN_LOG::find_next_log(LOG_INFO *linfo, bool need_lock_index) {
 
   linfo->index_file_offset = my_b_tell(&index_file);
 
+  linfo->last_read_pos = 0;
 err:
   if (need_lock_index) mysql_mutex_unlock(&LOCK_index);
   return error;
@@ -6032,6 +6038,10 @@ bool MYSQL_BIN_LOG::reset_logs(THD *thd, bool delete_only) {
 err:
   if (name == nullptr)
     name = const_cast<char *>(save_name);  // restore old file-name
+
+  if (!error && !is_relay_log) {
+    update_progress_tracker_logfiles(true);
+  }
   sid_lock->unlock();
   mysql_mutex_unlock(&LOCK_index);
   mysql_mutex_unlock(&LOCK_log);
@@ -6305,6 +6315,10 @@ err:
 
   DBUG_EXECUTE_IF("crash_purge_non_critical_after_update_index",
                   DBUG_SUICIDE(););
+
+  if (!error && !close_error_index && !error_index && !is_relay_log) {
+    update_progress_tracker_logfiles();
+  }
 
   if (need_lock_index) mysql_mutex_unlock(&LOCK_index);
 
@@ -6983,6 +6997,11 @@ end:
     close(LOG_CLOSE_INDEX, false /*need_lock_log=false*/,
           false /*need_lock_index=false*/);
   }
+  else {
+    if (!is_relay_log) {
+      update_progress_tracker_logfiles();
+    }
+  }
 
   mysql_mutex_unlock(&LOCK_index);
   if (need_lock_log) mysql_mutex_unlock(&LOCK_log);
@@ -7492,6 +7511,11 @@ int MYSQL_BIN_LOG::rotate(bool force_rotate, bool *check_purge) {
       (m_binlog_file->get_real_file_size() >= (my_off_t)max_size) ||
       DBUG_EVALUATE_IF("simulate_max_binlog_size", true, false)) {
     error = new_file_without_locking(nullptr);
+
+    if (cdb_page_cache_cleaning_binlog) {
+      progress_tracker.update_active_file(log_file_name);
+      progress_tracker.make_progress();
+    }
     *check_purge = true;
   }
   return error;
@@ -8284,6 +8308,11 @@ int MYSQL_BIN_LOG::open_binlog(const char *opt_name) {
   }
 
 err:
+  if (error == 0 && !is_relay_log) {
+    mysql_mutex_lock(&LOCK_index);
+    update_progress_tracker_logfiles(true);
+    mysql_mutex_unlock(&LOCK_index);
+  }
   if (should_execute_ha_recover) {
     error = ha_recover();
     if (error) LogErr(ERROR_LEVEL, ER_BINLOG_CRASH_RECOVERY_ERROR_RETURNED_SE);
@@ -12093,6 +12122,271 @@ bool check_binlog_cache_dbl_used(const THD *thd) {
   binlog_cache_mngr *cache_mngr = thd_get_cache_mngr(thd);
   return cache_mngr->all_finalized();
 }
+
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::init() {
+  mysql_mutex_init(key_BINLOG_LOCK_progress_tracker,
+                   &LOCK_binlog_progress_tracker, MY_MUTEX_INIT_SLOW);
+}
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::cleanup() {
+  mysql_mutex_destroy(&LOCK_binlog_progress_tracker);
+}
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::reset_pointers() {
+  mysql_mutex_assert_owner(&LOCK_binlog_progress_tracker);
+  data.last_cleaned_file_idx = 0;
+  data.last_cleaned_file_offset = 0;
+}
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::make_progress() {
+  mysql_mutex_lock(&LOCK_binlog_progress_tracker);
+  data.has_progress = true;
+  mysql_mutex_unlock(&LOCK_binlog_progress_tracker);
+}
+bool MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::has_progress() {
+  // It's tolerable to do a dirty read on this flag.
+  return data.has_progress;
+}
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::set_progress(bool made_progress) {
+  mysql_mutex_assert_owner(&LOCK_binlog_progress_tracker);
+  data.has_progress = made_progress;
+}
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::update_active_file(
+    const char *active_binlog_filename) {
+  mysql_mutex_lock(&LOCK_binlog_progress_tracker);
+  data.active_binlog_filename = active_binlog_filename;
+  mysql_mutex_unlock(&LOCK_binlog_progress_tracker);
+}
+static int compare_log_name(const char *log_1, const char *log_2);
+class LogFilenameEqual {
+ public:
+  LogFilenameEqual(const std::string &lhs = "") : lhs(lhs) {}
+  bool operator()(const std::string &rhs) const {
+    return compare_log_name(lhs.c_str(), rhs.c_str()) == 0;
+  }
+
+ private:
+  const std::string &lhs;
+};
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::update_last_clean_file_pos(
+    const std::string &new_dumper_at_file_name,
+    my_off_t new_dumper_at_file_pos) {
+  mysql_mutex_lock(&LOCK_binlog_progress_tracker);
+  LogFilenameEqual equal(new_dumper_at_file_name);
+  std::vector<std::string>::const_iterator it =
+      std::find_if(data.sorted_binlog_file_fullnames.begin(),
+                   data.sorted_binlog_file_fullnames.end(), equal);
+  if (it != data.sorted_binlog_file_fullnames.end()) {
+    int file_idx = it - data.sorted_binlog_file_fullnames.begin();
+    if (file_idx < data.last_cleaned_file_idx ||
+        (file_idx == data.last_cleaned_file_idx &&
+         new_dumper_at_file_pos < data.last_cleaned_file_offset)) {
+      data.last_cleaned_file_offset = new_dumper_at_file_pos;
+      data.last_cleaned_file_idx = file_idx;
+      DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+        sql_print_information(
+            "new dump thread read before the page"
+            " cache cleanup position, resetting pointers");
+      });
+    }
+  }
+  mysql_mutex_unlock(&LOCK_binlog_progress_tracker);
+}
+void MYSQL_BIN_LOG::BIN_LOG_PROGRESS_TRACKER::trigger_page_cache_cleanup(
+    const std::vector<std::string> &dumper_current_filenames,
+    const std::vector<my_off_t> &dumper_current_read_progress) {
+  mysql_mutex_lock(&LOCK_binlog_progress_tracker);
+  int min_file_idx = (int)data.sorted_binlog_file_fullnames.size();
+  my_off_t min_file_offset = std::numeric_limits<my_off_t>::max();
+  for (size_t i = 0; i < dumper_current_filenames.size(); ++i) {
+    LogFilenameEqual equal(dumper_current_filenames[i]);
+    std::vector<std::string>::const_iterator it =
+        std::find_if(data.sorted_binlog_file_fullnames.begin(),
+                     data.sorted_binlog_file_fullnames.end(), equal);
+    DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+      sql_print_information(
+          "dumper_current_filenames[%lu]: %s, "
+          "dumper_current_read_progress[%lu]: %llu",
+          i, dumper_current_filenames[i].c_str(), i,
+          dumper_current_read_progress[i]);
+    });
+    if (it != data.sorted_binlog_file_fullnames.end()) {
+      int dis = it - data.sorted_binlog_file_fullnames.begin();
+      if (dis < min_file_idx ||
+          (dis == min_file_idx &&
+           dumper_current_read_progress[i] < min_file_offset)) {
+        min_file_idx = dis;
+        min_file_offset = dumper_current_read_progress[i];
+      }
+    }
+  }
+  int num_dumpers = dumper_current_filenames.size();
+  if (num_dumpers == 0) {
+    // No slaves, clean the page cache of files before the active binlog file
+    DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+      sql_print_information("page cache cleaning without slaves");
+    });
+    if (data.active_binlog_filename.empty()) {
+      goto exit;
+    }
+    LogFilenameEqual equal(data.active_binlog_filename);
+    std::vector<std::string>::const_iterator it =
+        std::find_if(data.sorted_binlog_file_fullnames.begin(),
+                     data.sorted_binlog_file_fullnames.end(), equal);
+    if (it == data.sorted_binlog_file_fullnames.end()) goto exit;
+    min_file_idx = it - data.sorted_binlog_file_fullnames.begin();
+    ;
+    min_file_offset = 0;
+  } else {
+    DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+      sql_print_information("page cache cleaning with slaves");
+    });
+  }
+  DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+    sql_print_information(
+        "min_file %s(%d), min_file_offset %llu, "
+        "data.last_cleaned_file_idx %s(%d), "
+        "data.last_cleaned_file_offset %llu, "
+        "data.sorted_binlog_file_fullnames.size() %lu",
+        min_file_idx < (int)data.sorted_binlog_file_fullnames.size()
+            ? data.sorted_binlog_file_fullnames[min_file_idx].c_str()
+            : NULL,
+        min_file_idx, min_file_offset,
+        data.last_cleaned_file_idx <
+                (int)data.sorted_binlog_file_fullnames.size()
+            ? data.sorted_binlog_file_fullnames[data.last_cleaned_file_idx]
+                  .c_str()
+            : NULL,
+        data.last_cleaned_file_idx, data.last_cleaned_file_offset,
+        data.sorted_binlog_file_fullnames.size());
+  });
+  if (min_file_idx != (int)data.sorted_binlog_file_fullnames.size()) {
+    assert(min_file_offset != std::numeric_limits<my_off_t>::max());
+    for (int i = data.last_cleaned_file_idx; i <= min_file_idx; ++i) {
+      MY_STAT stat;
+      const char *log_filename = data.sorted_binlog_file_fullnames[i].c_str();
+      if (compare_log_name(log_filename, data.active_binlog_filename.c_str()) ==
+          0) {
+        // We avoid cleaning the active binlog file
+        // that is currently being written.
+        goto exit;
+      }
+      if (!mysql_file_stat(binlog->m_key_file_log, log_filename, &stat,
+                           MYF(0))) {
+        // Somehow errors occurred, probably because some files got purged.
+        // We skip the cleaning all together and catch up later
+        // when sorted_binlog_file_fullnames is up to date.
+        goto exit;
+      }
+      my_off_t file_size = stat.st_size;
+      assert(i != min_file_idx || file_size >= min_file_offset);
+      my_off_t start_off = data.last_cleaned_file_offset;
+      if (start_off > file_size) start_off = file_size;
+      for (;;) {
+        // If on the last file, we do not wish to clean the the area
+        // beyond min_file_offset as this area might be actively accessed
+        // by the dumper threads.
+        if (i == min_file_idx && start_off >= min_file_offset) {
+          break;
+        }
+        // We do not clean the area beyond the file size.
+        if (i < min_file_idx && start_off >= file_size) {
+          break;
+        }
+        // Cap the cleaning region to be valid area within a file
+        my_off_t len = cdb_page_cache_cleaning_window;
+
+        // We make sure the cleaning region size ==
+        // cdb_page_cache_cleaning_window except for the last remaining region
+        // of a file.
+        if (i == min_file_idx && start_off + len > min_file_offset) {
+          break;
+        }
+        if (start_off + len > file_size) {
+          len = file_size - start_off;
+        }
+        page_cache_post_cleaning_work(log_filename, start_off, len);
+        start_off += len;
+      }
+      if (i == min_file_idx) {
+        my_off_t last_cleaned_file_offset = start_off;
+        data.last_cleaned_file_offset = last_cleaned_file_offset;
+        data.last_cleaned_file_idx = min_file_idx;
+      } else {
+        assert(i < min_file_idx);
+        data.last_cleaned_file_offset = 0;
+        data.last_cleaned_file_idx = i + 1;
+      }
+    }
+  }
+exit:
+  set_progress(false);
+  mysql_mutex_unlock(&LOCK_binlog_progress_tracker);
+}
+void MYSQL_BIN_LOG::update_progress_tracker_logfiles(bool reset_pointers) {
+  /* This function is used to take a snapshot of the contents in binlog index file.
+  When binlog cache cleaning is disabled, the snapshot is not used. 
+  */
+  if (!cdb_page_cache_cleaning_binlog) return;
+
+  std::vector<string> filenames;
+  mysql_mutex_assert_owner(&LOCK_index);
+  /** If the index file is somehow closed, we skip reading the contents. */
+  if (!my_b_inited(&index_file)) return;
+  /** Reload the binlog file paths from the index file in sorted order. */
+  LOG_INFO linfo;
+  int error;
+  for (error = find_log_pos(&linfo, NULL, false /*need_lock_index=false*/);
+       !error; error = find_next_log(&linfo, false /*need_lock_index=false*/)) {
+    DBUG_PRINT("info", ("read log filename '%s'", linfo.log_file_name));
+    filenames.push_back(string(linfo.log_file_name));
+  }
+  mysql_mutex_lock(&progress_tracker.LOCK_binlog_progress_tracker);
+  progress_tracker.data.sorted_binlog_file_fullnames.swap(filenames);
+  if (reset_pointers) {
+    progress_tracker.reset_pointers();
+    progress_tracker.set_progress(false);
+  }
+  mysql_mutex_unlock(&progress_tracker.LOCK_binlog_progress_tracker);
+}
+void MYSQL_BIN_LOG::update_log_last_read_pos(LOG_INFO *linfo,
+                                             my_off_t last_read_off) {
+  mysql_mutex_lock(&LOCK_index);
+  assert(linfo->last_read_pos <= last_read_off);
+  linfo->last_read_pos = last_read_off;
+  mysql_mutex_unlock(&LOCK_index);
+}
+void MYSQL_BIN_LOG::page_cache_cleaning_make_progress() {
+  progress_tracker.make_progress();
+}
+void MYSQL_BIN_LOG::enable_page_cache_cleaning() {
+  if (!is_relay_log) {
+    mysql_mutex_lock(&LOCK_index);
+    update_progress_tracker_logfiles(true);
+    mysql_mutex_unlock(&LOCK_index);
+  }
+}
+void MYSQL_BIN_LOG::update_last_clean_file_pos(const std::string &log_filename,
+                                               my_off_t log_file_pos) {
+  progress_tracker.update_last_clean_file_pos(log_filename, log_file_pos);
+}
+void MYSQL_BIN_LOG::trigger_page_cache_cleanup() {
+  if (progress_tracker.has_progress() == false) {
+    return;
+  }
+  if (cdb_page_cache_cleaning_binlog == false) return;
+  DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+    sql_print_information("progress_tracker: made progress.");
+  });
+  std::vector<std::string> dumper_current_filenames;
+  std::vector<my_off_t> dumper_current_read_progress;
+  mysql_mutex_lock(&LOCK_replica_list);
+  mysql_mutex_lock(&LOCK_index);
+  page_cache_cleanning_collect_slave_log_progresses(
+      dumper_current_filenames, dumper_current_read_progress);
+  mysql_mutex_unlock(&LOCK_index);
+  mysql_mutex_unlock(&LOCK_replica_list);
+  progress_tracker.trigger_page_cache_cleanup(dumper_current_filenames,
+                                              dumper_current_read_progress);
+}
+
 /* Changes from TXSQL end.*/
 /** @} */
 

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -125,6 +125,8 @@ struct LOG_INFO {
   int entry_index;  // used in purge_logs(), calculatd in find_log_pos().
   int encrypted_header_size;
   uint8_t encrypted_version;
+  my_off_t last_read_pos;  // used in os page cache cleaning
+
   LOG_INFO()
       : index_file_offset(0),
         index_file_start_offset(0),
@@ -132,7 +134,8 @@ struct LOG_INFO {
         fatal(false),
         entry_index(0),
         encrypted_header_size(0),
-        encrypted_version(0) {
+        encrypted_version(0),
+        last_read_pos(0) {
     memset(log_file_name, 0, FN_REFLEN);
   }
 };
@@ -1156,6 +1159,63 @@ class MYSQL_BIN_LOG : public TC_LOG {
  public:
   bool wait_for_flushed_trxs_finished();
   /* Changes from TXSQL end. */
+  void update_log_last_read_pos(LOG_INFO *linfo, my_off_t last_read_off);
+  void update_last_clean_file_pos(const std::string &log_filename,
+                                  my_off_t log_file_pos);
+  void trigger_page_cache_cleanup();
+  void page_cache_cleaning_make_progress();
+  void enable_page_cache_cleaning();
+  struct binlog_progress_data_t {
+    /* A snapshot of the contents in binlog index file */
+    std::vector<std::string> sorted_binlog_file_fullnames;
+    /* The index into sorted_binlog_file_fullnames that indicates the
+      binlog file cleaned last time. */
+    int last_cleaned_file_idx;
+    /* The cleaninig offset of the last file.
+      This is used in combination with last_cleaned_file_idx.
+      (last_cleaned_file_idx, last_cleaned_file_offset) indicates
+      the cleaning progress at byte granularity . */
+    my_off_t last_cleaned_file_offset;
+    /* Current binlog file actively being written. */
+    std::string active_binlog_filename;
+    /* Whether there is any progress(data read/write, file rotations)
+    made by dump/writer threads. */
+    bool has_progress;
+    binlog_progress_data_t()
+        : last_cleaned_file_idx(0),
+          last_cleaned_file_offset(0),
+          has_progress(false) {}
+  };
+
+  /**
+   * This class tracks the binlog read progress of all dump threads.
+   * This is to help the page cache cleaner identify the safe cleaning
+   * position among all the binlog files.
+   */
+  class BIN_LOG_PROGRESS_TRACKER {
+   public:
+    BIN_LOG_PROGRESS_TRACKER(MYSQL_BIN_LOG *binlog) : binlog(binlog) {}
+    void init();
+    void cleanup();
+    void update_active_file(const char *active_binlog_filename);
+    void trigger_page_cache_cleanup(
+        const std::vector<std::string> &dumper_current_filenames,
+        const std::vector<my_off_t> &dumper_current_read_progress);
+    void update_last_clean_file_pos(const std::string &new_dumper_at_file_name,
+                                    my_off_t new_dumper_at_file_pos);
+    void reset_pointers();
+    void make_progress();
+    bool has_progress();
+    void set_progress(bool made_progress);
+    mysql_mutex_t LOCK_binlog_progress_tracker;
+
+    /* Updates to members of `data` is protected by
+    LOCK_binlog_progress_tracker.*/
+    binlog_progress_data_t data;
+    MYSQL_BIN_LOG *binlog;
+  };
+  void update_progress_tracker_logfiles(bool reset_pointers = false);
+  BIN_LOG_PROGRESS_TRACKER progress_tracker;
 };
 
 struct LOAD_FILE_INFO {

--- a/sql/iterators/row_iterator.h
+++ b/sql/iterators/row_iterator.h
@@ -26,6 +26,7 @@
 #include <assert.h>
 #include <string>
 #include <prealloced_array.h>
+#include <vector>
 
 class Item;
 class JOIN;

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1020,6 +1020,11 @@ static int show_threadpool_idle_threads(THD *thd MY_ATTRIBUTE((unused)),
 }
 #endif
 
+/* Cleaning window size for os page cache. */
+ulonglong cdb_page_cache_cleaning_window = 16 * 1024 * 1024;
+bool cdb_page_cache_cleaning_redo = true;
+bool cdb_page_cache_cleaning_binlog = true;
+
 #define mysqld_charset &my_charset_latin1
 #define mysqld_default_locale_name "en_US"
 
@@ -1172,6 +1177,8 @@ static PSI_mutex_key key_LOCK_rotate_binlog_master_key;
 static PSI_mutex_key key_LOCK_partial_revokes;
 static PSI_mutex_key key_LOCK_authentication_policy;
 static PSI_mutex_key key_LOCK_global_conn_mem_limit;
+PSI_mutex_key 
+  key_LOCK_page_cache_cleaning, key_BINLOG_LOCK_progress_tracker;
 #if defined(HAVE_OPT_CTX)
 static PSI_mutex_key key_LOCK_optimizer_context_memory_exceeded_counter;
 #endif
@@ -2799,7 +2806,7 @@ static void clean_up(bool print_message) {
   Statistics_manager::deinit();
 
   stop_handle_manager();
-
+  stop_page_cache_cleaner();
   memcached_shutdown();
 
   release_keyring_handles();
@@ -2952,6 +2959,7 @@ static void clean_up_mutexes() {
   mysql_mutex_destroy(&LOCK_log_throttle_qni);
   mysql_mutex_destroy(&LOCK_status);
   mysql_mutex_destroy(&LOCK_manager);
+  mysql_mutex_destroy(&LOCK_page_cache_cleaning);
   mysql_mutex_destroy(&LOCK_crypt);
   mysql_mutex_destroy(&LOCK_user_conn);
   mysql_rwlock_destroy(&LOCK_sys_init_connect);
@@ -2978,6 +2986,7 @@ static void clean_up_mutexes() {
   mysql_mutex_destroy(&LOCK_password_history);
   mysql_mutex_destroy(&LOCK_password_reuse_interval);
   mysql_cond_destroy(&COND_manager);
+  mysql_cond_destroy(&COND_page_cache_cleaning);
   mysql_mutex_destroy(&LOCK_transmit_client_access);
   mysql_mutex_destroy(&LOCK_stats_manager);
 #ifdef _WIN32
@@ -5720,6 +5729,8 @@ int init_common_variables() {
 static int init_thread_environment() {
   mysql_mutex_init(key_LOCK_status, &LOCK_status, MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_manager, &LOCK_manager, MY_MUTEX_INIT_FAST);
+  mysql_mutex_init(key_LOCK_page_cache_cleaning, &LOCK_page_cache_cleaning,
+                   MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_crypt, &LOCK_crypt, MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_user_conn, &LOCK_user_conn, MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_global_system_variables,
@@ -5807,6 +5818,7 @@ static int init_thread_environment() {
                    MY_MUTEX_INIT_FAST);
   mysql_mutex_init(key_LOCK_global_conn_mem_limit, &LOCK_global_conn_mem_limit,
                    MY_MUTEX_INIT_FAST);
+  mysql_cond_init(key_COND_page_cache_cleaning, &COND_page_cache_cleaning);
   Statistics_manager::init_mutexes();
 #if defined(HAVE_OPT_CTX)
   mysql_mutex_init(key_LOCK_optimizer_context_memory_exceeded_counter,
@@ -8762,6 +8774,7 @@ int mysqld_main(int argc, char **argv)
   }
 
   start_handle_manager();
+  start_cdb_os_page_cache_cleaning_thread();
 
   sql_print_information("%s is using '%s' malloc library", my_progname,
                         MALLOC_LIBRARY);
@@ -12667,6 +12680,8 @@ static PSI_mutex_info all_server_mutexes[]=
   { &key_LOCK_Sql_Filter_Rule, "Sql_Filter_Rule_mutex", 0, 0, PSI_DOCUMENT_ME},
   { &key_master_info_transmit_lock, "Master_info::transmit_lock", 0, 0, PSI_DOCUMENT_ME},
   { &key_LOCK_statistics_tasks_pool, "LOCK_stats_manager", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
+  { &key_LOCK_page_cache_cleaning, "page_cache_cleaning", 0, 0, PSI_DOCUMENT_ME},
+  { &key_BINLOG_LOCK_progress_tracker, "MYSQL_BIN_LOG::LOCK_progress_tracker", 0, 0, PSI_DOCUMENT_ME},
 #if defined(HAVE_OPT_CTX)
   { &key_LOCK_optimizer_context_memory_exceeded_counter, "LOCK_optimizer_context_memory_exceeded_counter",
      PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
@@ -12750,6 +12765,7 @@ PSI_cond_key key_monitor_info_run_cond;
 PSI_cond_key key_cond_binlog_flush_thread;
 PSI_cond_key key_COND_delegate_connection_cond_var;
 PSI_cond_key key_COND_group_replication_connection_cond_var;
+PSI_cond_key key_COND_page_cache_cleaning;
 
 /* clang-format off */
 static PSI_cond_info all_server_conds[]=
@@ -12794,7 +12810,8 @@ static PSI_cond_info all_server_conds[]=
   { &key_monitor_info_run_cond, "Source_IO_monitor::run_cond", 0, 0, PSI_DOCUMENT_ME},
   { &key_cond_binlog_flush_thread, "cond_binlog_flush_thread", 0, 0, PSI_DOCUMENT_ME},
   { &key_COND_delegate_connection_cond_var, "THD::COND_delegate_connection_cond_var", 0, 0, PSI_DOCUMENT_ME},
-  { &key_COND_group_replication_connection_cond_var, "THD::COND_group_replication_connection_cond_var", 0, 0, PSI_DOCUMENT_ME}
+  { &key_COND_group_replication_connection_cond_var, "THD::COND_group_replication_connection_cond_var", 0, 0, PSI_DOCUMENT_ME},
+  { &key_COND_page_cache_cleaning, "os_page_cache_cleaning", 0, 0, PSI_DOCUMENT_ME}
 };
 /* clang-format on */
 
@@ -12806,6 +12823,7 @@ PSI_thread_key key_thread_parser_service;
 PSI_thread_key key_thread_handle_con_admin_sockets;
 PSI_thread_key key_thread_binlog_flush;
 PSI_thread_key key_thread_sql_statistics_clear_expired_info;
+PSI_thread_key key_thread_os_page_cache_cleaning;
 
 /* clang-format off */
 static PSI_thread_info all_server_threads[]=
@@ -12827,6 +12845,7 @@ PSI_FLAG_USER | PSI_FLAG_NO_SEQNUM, 0, PSI_DOCUMENT_ME},
   { &key_thread_handle_con_admin_sockets, "admin_interface", "con_admin", PSI_FLAG_USER, 0, PSI_DOCUMENT_ME},
   { &key_thread_binlog_flush, "binlog_flush", "binlog_flush", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME},
   { &key_thread_sql_statistics_clear_expired_info, "sql_statistics", "sql_stat", PSI_FLAG_USER, 0, PSI_DOCUMENT_ME},
+  { &key_thread_os_page_cache_cleaning, "os_page_cache_cleaning", "working_mode", PSI_FLAG_SINGLETON, 0, PSI_DOCUMENT_ME}
 };
 /* clang-format on */
 

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -1038,5 +1038,15 @@ extern CThdBottomHalf *g_thdBottomHalf;
 extern bool g_txsql_enable_name_ack;
 extern bool txsql_show_kill_log;
 
+extern ulonglong cdb_page_cache_cleaning_window;
+extern bool cdb_page_cache_cleaning_redo;
+extern bool cdb_page_cache_cleaning_binlog;
+
+extern mysql_cond_t COND_page_cache_cleaning;
+extern PSI_cond_key key_LOCK_page_cache_cleaning,
+    key_BINLOG_LOCK_progress_tracker, key_COND_page_cache_cleaning;
+extern PSI_mutex_key key_thread_os_page_cache_cleaning;
+extern mysql_mutex_t LOCK_page_cache_cleaning;
+
 /* Changes from txsql end. */
 #endif /* MYSQLD_INCLUDED */

--- a/sql/os_page_cache.cc
+++ b/sql/os_page_cache.cc
@@ -1,0 +1,150 @@
+#include "os_page_cache.h"
+#include <sql/malloc_allocator.h>
+#include <my_sys.h>
+#include <boost/functional/hash.hpp>
+#include <list>
+#include <unordered_set>
+#include "log.h"  // sql_print_information
+#include "my_systime.h"
+
+struct page_cache_cleaning_t {
+  std::string filename_full;
+  File fd;
+  my_off_t start_off;
+  my_off_t len;
+  page_cache_cleaning_t(const char *filename_full, my_off_t start_off,
+                        my_off_t len)
+      : filename_full(filename_full), start_off(start_off), len(len) {
+    fd = -1;
+  }
+  page_cache_cleaning_t(File fd, my_off_t start_off, my_off_t len)
+      : fd(fd), start_off(start_off), len(len) {}
+  bool operator==(const page_cache_cleaning_t &other) const {
+    if (filename_full == other.filename_full && start_off == other.start_off &&
+        len == other.len) {
+      return true;
+    }
+    return false;
+  }
+};
+
+namespace std {
+template <>
+struct hash<page_cache_cleaning_t> {
+  std::size_t operator()(const page_cache_cleaning_t &c) const {
+    std::size_t result = 0;
+    if (!c.filename_full.empty()) {
+      boost::hash_combine(result, c.filename_full);
+    }
+    boost::hash_combine(result, c.fd);
+    boost::hash_combine(result, c.start_off);
+    boost::hash_combine(result, c.start_off + c.len);
+    return result;
+  }
+};
+}  // namespace std
+
+mysql_mutex_t LOCK_page_cache_cleaning;
+mysql_cond_t COND_page_cache_cleaning;
+typedef std::list<page_cache_cleaning_t,
+                  Malloc_allocator<page_cache_cleaning_t>>
+    cleaning_task_list_t;
+typedef std::unordered_set<page_cache_cleaning_t,
+                           std::hash<page_cache_cleaning_t>,
+                           std::equal_to<page_cache_cleaning_t>,
+                           Malloc_allocator<page_cache_cleaning_t>>
+    cleaning_task_hashmap_t;
+cleaning_task_list_t page_cache_clean_list(
+    (Malloc_allocator<page_cache_cleaning_t>(key_memory_page_cache_clean)));
+cleaning_task_hashmap_t page_cache_clean_hashmap(
+    (Malloc_allocator<page_cache_cleaning_t>(key_memory_page_cache_clean)));
+
+void page_cache_post_cleaning_work(const char *filename_full,
+                                   my_off_t start_off, my_off_t len) {
+#ifdef POSIX_FADV_DONTNEED
+  page_cache_cleaning_t pc =
+      page_cache_cleaning_t(filename_full, start_off, len);
+  mysql_mutex_lock(&LOCK_page_cache_cleaning);
+  if (page_cache_clean_hashmap.find(pc) == page_cache_clean_hashmap.end()) {
+    page_cache_clean_hashmap.insert(pc);
+    page_cache_clean_list.push_back(std::move(pc));
+  }
+  // Wake up the cleaning worker thread
+  mysql_cond_signal(&COND_page_cache_cleaning);
+  mysql_mutex_unlock(&LOCK_page_cache_cleaning);
+#endif /* POSIX_FADV_DONTNEED */
+}
+
+void page_cache_post_cleaning_work(File fd, my_off_t start_off, my_off_t len) {
+#ifdef POSIX_FADV_DONTNEED
+  page_cache_cleaning_t pc = page_cache_cleaning_t(fd, start_off, len);
+  mysql_mutex_lock(&LOCK_page_cache_cleaning);
+  /* Nothing will repeatedly pull redo logs. Just care about binlogs here */
+  page_cache_clean_list.push_back(std::move(pc));
+  // Wake up the cleaning worker thread
+  mysql_cond_signal(&COND_page_cache_cleaning);
+  mysql_mutex_unlock(&LOCK_page_cache_cleaning);
+#endif /* POSIX_FADV_DONTNEED */
+}
+
+extern MYSQL_PLUGIN_IMPORT bool volatile abort_page_cache_cleaner;
+
+void page_cache_cleanup() {
+  mysql_mutex_lock(&LOCK_page_cache_cleaning);
+  while (!page_cache_clean_list.empty()) {
+    page_cache_clean_list.pop_front();
+  }
+  mysql_mutex_unlock(&LOCK_page_cache_cleaning);
+}
+
+void page_cache_process_cleaning_work() {
+  struct timespec abstime;
+  int error = 0;
+  mysql_mutex_lock(&LOCK_page_cache_cleaning);
+  if (page_cache_clean_list.empty()) {
+    set_timespec(&abstime, 1);
+    while ((!error || error == EINTR) && !abort_page_cache_cleaner)
+      error = mysql_cond_timedwait(&COND_page_cache_cleaning,
+                                   &LOCK_page_cache_cleaning, &abstime);
+    mysql_mutex_unlock(&LOCK_page_cache_cleaning);
+    return;
+  }
+  page_cache_cleaning_t clean = page_cache_clean_list.front();
+  page_cache_clean_list.pop_front();
+  mysql_mutex_unlock(&LOCK_page_cache_cleaning);
+  File fd = clean.fd;
+  bool opened = false;
+  if (fd == -1) {
+    fd = ::open(clean.filename_full.c_str(), O_RDONLY);
+    opened = true;
+  }
+#ifdef POSIX_FADV_DONTNEED
+  if (fd != -1) {
+    // Since this is merely an advice to the operating system,
+    // we don't care if the fadvise succeeded or not.
+    ::posix_fadvise(fd, clean.start_off, clean.len, POSIX_FADV_DONTNEED);
+  }
+
+  DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+    if (!clean.filename_full.empty())
+      sql_print_information(
+          "POSIX_FADV_DONTNEED on file %s, range[%llu, %llu), length %llu",
+          clean.filename_full.c_str(), clean.start_off,
+          clean.start_off + clean.len, clean.len);
+    else
+      sql_print_information(
+          "POSIX_FADV_DONTNEED on file fd %d, range[%llu, %llu), length %llu",
+          fd, clean.start_off, clean.start_off + clean.len, clean.len);
+  });
+
+#endif /* POSIX_FADV_DONTNEED */
+  if (opened) {
+    ::close(fd);
+  }
+}
+
+void page_cache_wake_up_worker() {
+  mysql_mutex_lock(&LOCK_page_cache_cleaning);
+  mysql_cond_signal(&COND_page_cache_cleaning);
+  mysql_mutex_unlock(&LOCK_page_cache_cleaning);
+}

--- a/sql/os_page_cache.h
+++ b/sql/os_page_cache.h
@@ -1,0 +1,23 @@
+#ifndef OS_PAGE_CACHE_INCLUDED
+#define OS_PAGE_CACHE_INCLUDED
+#include "include/mysql/psi/mysql_cond.h"
+#include "include/mysql/psi/mysql_mutex.h"
+#include "my_thread.h"
+#include "mysql/psi/mysql_file.h"
+
+extern mysql_mutex_t LOCK_page_cache_cleaning;
+extern mysql_cond_t COND_page_cache_cleaning;
+extern PSI_memory_key key_memory_page_cache_clean;
+
+extern void page_cache_post_cleaning_work(const char *filename_full,
+                                          my_off_t start_off, my_off_t len);
+
+extern void page_cache_post_cleaning_work(File fd, my_off_t start_off,
+                                          my_off_t len);
+
+extern void page_cache_process_cleaning_work();
+
+extern void page_cache_wake_up_worker();
+
+extern void page_cache_cleanup();
+#endif /* OS_PAGE_CACHE_INCLUDED */

--- a/sql/psi_memory_key.cc
+++ b/sql/psi_memory_key.cc
@@ -151,6 +151,7 @@ PSI_memory_key key_memory_statistics_task;
 #if defined(HAVE_OPT_CTX)
 PSI_memory_key key_memory_optimizer_context;
 #endif
+PSI_memory_key key_memory_page_cache_clean;
 
 #ifdef HAVE_PSI_INTERFACE
 
@@ -396,17 +397,19 @@ static PSI_memory_info all_server_memory[] = {
      "Memory allocated for in-memory sets for persisted variables"},
     {&key_memory_thread_pool_connection, "thread_pool_connection", 0, 0,
      PSI_DOCUMENT_ME},
-    {&key_memory_hot_update_metadata, "hot_update_metadata", 0, 0, 
+    {&key_memory_hot_update_metadata, "hot_update_metadata", 0, 0,
      PSI_DOCUMENT_ME},
-    {&key_memory_statistics_manager,"statistics_manager", 0, 0,
+    {&key_memory_statistics_manager, "statistics_manager", 0, 0,
      PSI_DOCUMENT_ME},
-    {&key_memory_statistics_task,"statistics_manager_task", 0, 0,
+    {&key_memory_statistics_task, "statistics_manager_task", 0, 0,
      PSI_DOCUMENT_ME},
+    {&key_memory_page_cache_clean, "cdb_page_cache_clean", 0,0,PSI_DOCUMENT_ME}
 #if defined(HAVE_OPT_CTX)
-    {&key_memory_optimizer_context, "optimization context for parallel execution", 0, 0,
-     PSI_DOCUMENT_ME}
+    ,
+    {&key_memory_optimizer_context,
+     "optimization context for parallel execution", 0, 0, PSI_DOCUMENT_ME}
 #endif
-    };
+};
 
 void register_server_memory_keys() {
   const char *category = "sql";

--- a/sql/rpl_binlog_sender.cc
+++ b/sql/rpl_binlog_sender.cc
@@ -67,6 +67,8 @@
 #include "typelib.h"
 #include "unsafe_string_append.h"
 
+#include "os_page_cache.h"
+
 #ifndef NDEBUG
 static uint binlog_dump_count = 0;
 volatile uint kill_binlog_dump= 0;
@@ -300,7 +302,7 @@ void Binlog_sender::init() {
 
   LogErr(INFORMATION_LEVEL, ER_RPL_BINLOG_STARTING_DUMP, thd->thread_id(),
          thd->server_id, m_start_file, m_start_pos);
-
+  mysql_bin_log.page_cache_cleaning_make_progress();
   {
     long long int cdb_replica_role;
     if (!get_user_var_int("cdb_replica_role", &cdb_replica_role, nullptr)) {
@@ -397,6 +399,7 @@ void Binlog_sender::run() {
   my_off_t start_pos = m_start_pos;
   const char *log_file = m_linfo.log_file_name;
   bool is_index_file_reopened_on_binlog_disable = false;
+  mysql_bin_log.update_last_clean_file_pos(log_file, start_pos);
 
   reader.allocator()->set_sender(this);
   while (!has_error() && !m_thd->killed) {
@@ -456,6 +459,18 @@ void Binlog_sender::run() {
                             true /*need_lock_index=true*/);
       set_fatal_error("could not find next log");
       break;
+    }
+
+    if (cdb_page_cache_cleaning_binlog) {
+      mysql_bin_log.page_cache_cleaning_make_progress();
+      DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+        sql_print_information(
+            "A cdb_page_cache_cleaning_window of"
+            " binlog data is sent to slave or reached EOF.");
+      });
+      DBUG_EXECUTE_IF("trigger_page_cache_cleanup_after_reading_a_binlog_file",
+                      { mysql_bin_log.trigger_page_cache_cleanup(); });
+      page_cache_wake_up_worker();
     }
 
     start_pos = BIN_LOG_HEADER_SIZE;
@@ -686,6 +701,20 @@ int Binlog_sender::send_events(File_reader *reader, my_off_t end_pos) {
 
     if (unlikely(after_send_hook(log_file, in_exclude_group ? log_pos : 0)))
       return 1;
+
+    my_off_t read_pos = log_pos;
+    assert(read_pos >= m_linfo.last_read_pos);
+    if (cdb_page_cache_cleaning_binlog &&
+        (read_pos - m_linfo.last_read_pos >= cdb_page_cache_cleaning_window)) {
+      mysql_bin_log.update_log_last_read_pos(&m_linfo, read_pos);
+      mysql_bin_log.page_cache_cleaning_make_progress();
+      DBUG_EXECUTE_IF("page_cache_cleaning_test", {
+        sql_print_information(
+            "A cdb_page_cache_cleaning_window of"
+            " binlog data is sent to slave or reached EOF.");
+      });
+      page_cache_wake_up_worker();
+    }
   }
 
   /*

--- a/sql/rpl_source.cc
+++ b/sql/rpl_source.cc
@@ -1534,3 +1534,24 @@ err:
   mysql_bin_log.unlock_index();
   return true;
 }
+
+void page_cache_cleanning_collect_slave_log_progresses(
+    std::vector<std::string> &dumper_current_filenames,
+    std::vector<my_off_t> &dumper_current_read_progress) {
+  mysql_mutex_assert_owner(&LOCK_replica_list);
+  for (const auto &si : slave_list) {
+    Find_thd_with_id find_thd_with_id(si.second->thd_id);
+    THD *thd = Global_THD_manager::get_instance()->find_thd(&find_thd_with_id).get();
+
+    if (thd == nullptr) {
+      // the SLAVE_INFO is just registering
+      continue;
+    }
+    mysql_mutex_lock(&thd->LOCK_thd_data);
+    if (thd->current_linfo) {
+      dumper_current_filenames.push_back(thd->current_linfo->log_file_name);
+      dumper_current_read_progress.push_back(thd->current_linfo->last_read_pos);
+    }
+    mysql_mutex_unlock(&thd->LOCK_thd_data);
+  }
+}

--- a/sql/rpl_source.h
+++ b/sql/rpl_source.h
@@ -33,6 +33,10 @@
 #include "mysql_com.h"        // USERNAME_LENGTH
 #include "sql/sql_const.h"    // MAX_PASSWORD_LENGTH
 
+#include <string>
+#include <vector>
+
+
 class Gtid_set;
 class String;
 class THD;
@@ -139,5 +143,10 @@ class user_var_entry;
 const user_var_entry *get_user_var_from_alternatives(const THD *thd,
                                                      const std::string alt1,
                                                      const std::string alt2);
+
+
+void page_cache_cleanning_collect_slave_log_progresses(
+    std::vector<std::string> &dumper_current_filenames,
+    std::vector<my_off_t> &dumper_current_read_progress);
 
 #endif /* RPL_SOURCE_H_INCLUDED */

--- a/sql/sql_manager.cc
+++ b/sql/sql_manager.cc
@@ -50,8 +50,12 @@
 #include "sql/sql_base.h"  // tdc_flush_unused_tables
 #include "sql/opt_statistics.h"
 
+#include "binlog.h"
+#include "os_page_cache.h"
+
 static bool volatile manager_thread_in_use;
 static bool abort_manager;
+bool volatile abort_page_cache_cleaner;
 
 my_thread_t manager_thread;
 mysql_mutex_t LOCK_manager;
@@ -155,4 +159,47 @@ void stop_handle_manager() {
     mysql_cond_signal(&COND_manager);
   }
   mysql_mutex_unlock(&LOCK_manager);
+}
+
+extern mysql_mutex_t LOCK_page_cache_cleaning;
+extern mysql_cond_t COND_page_cache_cleaning;
+
+extern MYSQL_BIN_LOG mysql_bin_log;
+extern "C" void *cdb_os_page_cache_cleaning_thread(void *arg
+                                                   __attribute__((unused))) {
+  my_thread_init();
+  while (!abort_page_cache_cleaner) {
+    page_cache_process_cleaning_work();
+    if (abort_page_cache_cleaner) break;
+    if (opt_bin_log) {
+      mysql_bin_log.trigger_page_cache_cleanup();
+    }
+  }
+  page_cache_cleanup();
+  my_thread_end();
+  return (NULL);
+}
+
+void start_cdb_os_page_cache_cleaning_thread() {
+  DBUG_ENTER("start_cdb_os_page_cache_cleaning_thread");
+
+  my_thread_handle hThread;
+  int error;
+  if ((error = mysql_thread_create(key_thread_os_page_cache_cleaning, &hThread,
+                                   &connection_attrib,
+                                   cdb_os_page_cache_cleaning_thread, 0)))
+    sql_print_warning(
+        "TXSQL: Can't start os page cache cleaning thread(errno= %d)", error);
+
+  DBUG_VOID_RETURN;
+}
+
+/* Initiate shutdown of page cache cleaner thread */
+void stop_page_cache_cleaner() {
+  DBUG_ENTER("stop_page_cache_cleaner");
+  abort_page_cache_cleaner = true;
+  mysql_mutex_lock(&LOCK_page_cache_cleaning);
+  mysql_cond_signal(&COND_page_cache_cleaning);
+  mysql_mutex_unlock(&LOCK_page_cache_cleaning);
+  DBUG_VOID_RETURN;
 }

--- a/sql/sql_manager.h
+++ b/sql/sql_manager.h
@@ -27,4 +27,7 @@ void start_handle_manager();
 void stop_handle_manager();
 void start_cdb_sql_statistics_clear_expired_info_thread();
 
+void stop_page_cache_cleaner();
+void start_cdb_os_page_cache_cleaning_thread();
+
 #endif /* SQL_MANAGER_INCLUDED */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -9209,4 +9209,39 @@ static Sys_var_bool Sys_txsql_show_kill_log(
     DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
     ON_UPDATE(NULL));
 
+static bool update_cdb_page_cache_cleaning_binlog(sys_var *self, THD *thd,
+                                                  enum_var_type type) {
+  if (opt_bin_log) {
+    if (cdb_page_cache_cleaning_binlog == true) {
+      mysql_bin_log.enable_page_cache_cleaning();
+    }
+  }
+  return false;
+}
+static Sys_var_ulonglong Sys_page_cache_cleaning_window(
+    "cdb_page_cache_cleaning_window",
+    "Cleaning window size for page cache in bytes. Default is "
+    "16,777,216(16MB).",
+    GLOBAL_VAR(cdb_page_cache_cleaning_window), CMD_LINE(OPT_ARG),
+    VALID_RANGE(1024 * 1024, 1024 * 1024 * 1024), DEFAULT(16 * 1024 * 1024),
+    BLOCK_SIZE(1));
+static Sys_var_bool Sys_cdb_enable_page_cache_cleaning_redo(
+    "cdb_page_cache_cleaning_redo",
+    "5.7 Compatable Var: No effect in 8.0.30",
+    GLOBAL_VAR(cdb_page_cache_cleaning_redo), CMD_LINE(OPT_ARG),
+    DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
+    ON_UPDATE(NULL));
+static Sys_var_bool Sys_cdb_enable_page_cache_cleaning_binlog(
+    "cdb_page_cache_cleaning_binlog",
+    "Enable page cache cleaning for binlog files",
+    GLOBAL_VAR(cdb_page_cache_cleaning_binlog), CMD_LINE(OPT_ARG),
+    DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
+    ON_UPDATE(update_cdb_page_cache_cleaning_binlog));
+
+bool cdb_sql_mode_fixup_enabled = false;
+static Sys_var_bool Sys_cdb_sql_mode_fixup_enabled(
+    "cdb_sql_mode_fixup_enabled", "5.7 Compatable Var: No effect in 8.0.30",
+    GLOBAL_VAR(cdb_sql_mode_fixup_enabled), CMD_LINE(OPT_ARG),
+    DEFAULT(false));
+
 /* Changes from txsql end. */


### PR DESCRIPTION
Problem:
========
OS page cache contains lots of log data, freeing them will cause performance issue.

Solution:
=======
Use posix_fadvise(POSIX_FADV_DONTNEED) to proactively clean OS page cache after binlog data has been flushed/synced, preventing large amounts of stale log data from accumulating in page cache.

Key changes:
- Add OsPageCache abstraction wrapping posix_fadvise() for page cache eviction
- Add BinlogProgressTracker in MYSQL_BIN_LOG to track flushed positions and drive page cache cleaning windows
- Integrate page cache cleaning into binlog flush/sync pipeline and binlog sender (dump thread)
- Add background thread (os_page_cache_cleaning) managed via sql_manager for periodic cleaning coordination
- Add 3 new system variables: cdb_page_cache_cleaning_binlog – enable binlog page cache cleaning cdb_page_cache_cleaning_window – cleaning window size in bytes cdb_page_cache_cleaning_redo
- Register new PSI mutex/cond/thread instrumentation keys
- Add MTR test cases for single-node and master-slave scenarios