### PR TITLE
[perf] issue#83 try lock LOCK_index for binlog rotate

### DIFF
--- a/mysql-test/suite/binlog/r/txsql_binlog_rotate_try_lock_index.result
+++ b/mysql-test/suite/binlog/r/txsql_binlog_rotate_try_lock_index.result
@@ -1,0 +1,38 @@
+reset master;
+show binary logs;
+Log_name	File_size	Encrypted	Algorithm
+binlog.000001	#	No	No
+create table t1(id int,c1 varchar(4096));
+insert into t1 values(1,'a');
+flush binary logs;
+set global max_binlog_size=4096;
+show binary logs;
+Log_name	File_size	Encrypted	Algorithm
+binlog.000001	#	No	No
+binlog.000002	#	No	No
+begin;
+insert into t1 values(2,repeat('b',4096));
+insert into t1 values(3,repeat('c',4096));
+commit;
+show binary logs;
+Log_name	File_size	Encrypted	Algorithm
+binlog.000001	#	No	No
+binlog.000002	#	No	No
+binlog.000003	#	No	No
+set debug_sync='txsql_purge_binlog_wait_after_lock_index signal txsql_binlog_index_locked wait_for txsql_purge_binlog_continue';
+purge binary logs to 'binlog.000002';
+set debug_sync='now wait_for txsql_binlog_index_locked';
+set debug_sync='txsql_try_lock_index_failed signal txsql_try_lock_index_failed_rotate_finished';
+set global txsql_binlog_rotate_try_lock_index=ON;
+begin;
+insert into t1 values(4,repeat('b',4096));
+insert into t1 values(5,repeat('c',4096));
+commit;
+set debug_sync='now signal txsql_purge_binlog_continue wait_for txsql_try_lock_index_failed_rotate_finished';
+show binary logs;
+Log_name	File_size	Encrypted	Algorithm
+binlog.000002	#	No	No
+binlog.000003	#	No	No
+drop table t1;
+set global max_binlog_size=default;
+set global txsql_binlog_rotate_try_lock_index=default;

--- a/mysql-test/suite/binlog/t/txsql_binlog_rotate_try_lock_index-master.opt
+++ b/mysql-test/suite/binlog/t/txsql_binlog_rotate_try_lock_index-master.opt
@@ -1,0 +1,1 @@
+--log-bin=binlog

--- a/mysql-test/suite/binlog/t/txsql_binlog_rotate_try_lock_index.test
+++ b/mysql-test/suite/binlog/t/txsql_binlog_rotate_try_lock_index.test
@@ -1,0 +1,50 @@
+source include/have_debug_sync.inc;
+source include/have_binlog_format_row.inc;
+
+connect (con1,localhost,root,,);
+connection default;
+
+reset master;
+--replace_column 2 #
+show binary logs;
+create table t1(id int,c1 varchar(4096));
+insert into t1 values(1,'a');
+
+flush binary logs;
+set global max_binlog_size=4096;
+
+connection con1;
+--replace_column 2 #
+show binary logs;
+
+begin;
+insert into t1 values(2,repeat('b',4096));
+insert into t1 values(3,repeat('c',4096));
+commit;
+
+--replace_column 2 #
+show binary logs;
+
+set debug_sync='txsql_purge_binlog_wait_after_lock_index signal txsql_binlog_index_locked wait_for txsql_purge_binlog_continue';
+send purge binary logs to 'binlog.000002';
+
+connection default;
+set debug_sync='now wait_for txsql_binlog_index_locked';
+set debug_sync='txsql_try_lock_index_failed signal txsql_try_lock_index_failed_rotate_finished';
+set global txsql_binlog_rotate_try_lock_index=ON;
+begin;
+insert into t1 values(4,repeat('b',4096));
+insert into t1 values(5,repeat('c',4096));
+commit;
+
+set debug_sync='now signal txsql_purge_binlog_continue wait_for txsql_try_lock_index_failed_rotate_finished';
+--replace_column 2 #
+show binary logs;
+
+connection con1;
+reap;
+disconnect con1;
+connection default;
+drop table t1;
+set global max_binlog_size=default;
+set global txsql_binlog_rotate_try_lock_index=default;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -3245,7 +3245,7 @@ bool purge_source_logs_to_file(THD *thd, const char *to_log) {
   mysql_bin_log.make_log_name(search_file_name, to_log);
   auto purge_error = mysql_bin_log.purge_logs(
       search_file_name, include_to_log, need_index_lock, need_update_threads,
-      nullptr, auto_purge);
+      nullptr, auto_purge, txsql_binlog_purge_check_file_count);
   return purge_error_message(thd, purge_error);
 }
 
@@ -4798,7 +4798,8 @@ bool MYSQL_BIN_LOG::init_gtid_sets(Gtid_set *all_gtids, Gtid_set *lost_gtids,
                                    bool verify_checksum, bool need_lock,
                                    Transaction_boundary_parser *trx_parser,
                                    Gtid_monitoring_info *partial_trx,
-                                   bool is_server_starting) {
+                                   bool is_server_starting, bool add_log,
+                                   ulonglong check_file_count) {
   DBUG_TRACE;
   DBUG_PRINT(
       "info",
@@ -4842,7 +4843,7 @@ bool MYSQL_BIN_LOG::init_gtid_sets(Gtid_set *all_gtids, Gtid_set *lost_gtids,
     sid_map = lost_gtids->get_sid_map();
 
   // Gather the set of files to be accessed.
-  auto log_index = this->get_log_index(false);
+  auto log_index = this->get_log_index(false, check_file_count);
   std::list<std::string> filename_list = log_index.second;
   int error = log_index.first;
   list<string>::iterator it;
@@ -5052,6 +5053,11 @@ bool MYSQL_BIN_LOG::init_gtid_sets(Gtid_set *all_gtids, Gtid_set *lost_gtids,
           goto end;
         }
         case NO_GTIDS:
+          if (check_file_count != 0) {
+            error = 1;
+            goto end;
+          }
+          [[fallthrough]];
         case GOT_PREVIOUS_GTIDS: {
           /*
             Mysql server iterates forwards through binary logs, looking for
@@ -5841,7 +5847,7 @@ int MYSQL_BIN_LOG::find_next_relay_log(char log_name[FN_REFLEN + 1]) {
 }
 
 std::pair<int, std::list<std::string>> MYSQL_BIN_LOG::get_log_index(
-    bool need_lock_index) {
+    bool need_lock_index, ulonglong file_count) {
   DBUG_TRACE;
   LOG_INFO log_info;
 
@@ -5852,11 +5858,19 @@ std::pair<int, std::list<std::string>> MYSQL_BIN_LOG::get_log_index(
 
   std::list<std::string> filename_list;
   int error = 0;
+  ulonglong count = 0;
   for (error =
            this->find_log_pos(&log_info, nullptr, false /*need_lock_index*/);
        error == 0;
        error = this->find_next_log(&log_info, false /*need_lock_index*/)) {
     filename_list.push_back(std::string(log_info.log_file_name));
+    if (file_count != 0) {
+      count++;
+      if (count >= file_count) {
+        error = LOG_INFO_EOF;
+        break;
+      }
+    }
   }
 
   if (need_lock_index) mysql_mutex_unlock(&LOCK_index);
@@ -6211,7 +6225,8 @@ err:
 
 int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
                               bool need_lock_index, bool need_update_threads,
-                              ulonglong *decrease_log_space, bool auto_purge) {
+                              ulonglong *decrease_log_space, bool auto_purge,
+                              ulonglong check_file_count) {
   int error = 0, no_of_log_files_to_purge = 0, no_of_log_files_purged = 0;
   int no_of_threads_locking_log = 0;
   bool exit_loop = false;
@@ -6224,6 +6239,9 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
     mysql_mutex_lock(&LOCK_index);
   else
     mysql_mutex_assert_owner(&LOCK_index);
+
+  DEBUG_SYNC(current_thd, "txsql_purge_binlog_wait_after_lock_index");
+
   if ((error =
            find_log_pos(&log_info, to_log, false /*need_lock_index=false*/))) {
     LogErr(ERROR_LEVEL, ER_BINLOG_PURGE_LOGS_CALLED_WITH_FILE_NOT_IN_INDEX,
@@ -6292,10 +6310,32 @@ int MYSQL_BIN_LOG::purge_logs(const char *to_log, bool included,
   // Update gtid_state->lost_gtids
   if (!is_relay_log) {
     global_sid_lock->wrlock();
-    error = init_gtid_sets(
-        nullptr, const_cast<Gtid_set *>(gtid_state->get_lost_gtids()),
-        opt_source_verify_checksum, false /*false=don't need lock*/,
-        nullptr /*trx_parser*/, nullptr /*partial_trx*/);
+    if (check_file_count != 0) {
+      Gtid_set *lost_gtids =
+          const_cast<Gtid_set *>(gtid_state->get_lost_gtids());
+      Gtid_set temp_lost_gtids(global_sid_map, nullptr);
+      error = init_gtid_sets(
+          nullptr, &temp_lost_gtids, opt_source_verify_checksum,
+          false /*false=don't need lock*/, nullptr /*trx_parser*/,
+          nullptr /*partial_trx*/, false, false, check_file_count);
+      if (error || temp_lost_gtids.is_empty()) {
+        temp_lost_gtids.clear();
+        sql_print_warning(
+            "[TXSQL] failed to init gtids while "
+            "txsql_binlog_purge_check_file_count=%lu, error: %d",
+            check_file_count, error);
+        error = init_gtid_sets(nullptr, lost_gtids, opt_source_verify_checksum,
+                               false /*false=don't need lock*/,
+                               nullptr /*trx_parser*/, nullptr /*partial_trx*/);
+      } else {
+        lost_gtids->add_gtid_set(&temp_lost_gtids);
+      }
+    } else {
+      error = init_gtid_sets(
+          nullptr, const_cast<Gtid_set *>(gtid_state->get_lost_gtids()),
+          opt_source_verify_checksum, false /*false=don't need lock*/,
+          nullptr /*trx_parser*/, nullptr /*partial_trx*/);
+    }
     global_sid_lock->unlock();
     if (error) goto err;
   }
@@ -6752,7 +6792,8 @@ void MYSQL_BIN_LOG::dec_prep_xids(THD *thd) {
 
 int MYSQL_BIN_LOG::new_file(
     Format_description_log_event *extra_description_event) {
-  return new_file_impl(true /*need_lock_log=true*/, extra_description_event);
+  return new_file_impl(true /*need_lock_log=true*/, extra_description_event,
+                       false);
 }
 
 /*
@@ -6760,8 +6801,10 @@ int MYSQL_BIN_LOG::new_file(
     nonzero - error
 */
 int MYSQL_BIN_LOG::new_file_without_locking(
-    Format_description_log_event *extra_description_event) {
-  return new_file_impl(false /*need_lock_log=false*/, extra_description_event);
+    Format_description_log_event *extra_description_event,
+    bool try_lock_index) {
+  return new_file_impl(false /*need_lock_log=false*/, extra_description_event,
+                       try_lock_index);
 }
 
 /**
@@ -6780,7 +6823,8 @@ int MYSQL_BIN_LOG::new_file_without_locking(
   @note The new file name is stored last in the index file
 */
 int MYSQL_BIN_LOG::new_file_impl(
-    bool need_lock_log, Format_description_log_event *extra_description_event) {
+    bool need_lock_log, Format_description_log_event *extra_description_event,
+    bool try_lock_index) {
   int error = 0;
   bool close_on_error = false;
   char new_name[FN_REFLEN], *new_name_ptr = nullptr, *old_name, *file_to_open;
@@ -6800,6 +6844,15 @@ int MYSQL_BIN_LOG::new_file_impl(
     mysql_mutex_assert_owner(&LOCK_log);
   DBUG_EXECUTE_IF("semi_sync_3-way_deadlock",
                   DEBUG_SYNC(current_thd, "before_rotate_binlog"););
+
+  if (try_lock_index) {
+    error = mysql_mutex_trylock(&LOCK_index);
+    if (error != 0) {
+      /* lock failed */
+      return TRY_LOCK_INDEX_FAIL;
+    }
+  }
+
   mysql_mutex_lock(&LOCK_xids);
   /*
     We need to ensure that the number of prepared XIDs are 0.
@@ -6814,7 +6867,9 @@ int MYSQL_BIN_LOG::new_file_impl(
   }
   mysql_mutex_unlock(&LOCK_xids);
 
-  mysql_mutex_lock(&LOCK_index);
+  if (!try_lock_index) {
+    mysql_mutex_lock(&LOCK_index);
+  }
 
   mysql_mutex_assert_owner(&LOCK_log);
   mysql_mutex_assert_owner(&LOCK_index);
@@ -7498,7 +7553,8 @@ bool MYSQL_BIN_LOG::write_event(Log_event *event_info) {
   @retval
     nonzero - error in rotating routine.
 */
-int MYSQL_BIN_LOG::rotate(bool force_rotate, bool *check_purge) {
+int MYSQL_BIN_LOG::rotate(bool force_rotate, bool *check_purge,
+                          bool try_lock_index) {
   int error = 0;
   DBUG_TRACE;
 
@@ -7510,8 +7566,11 @@ int MYSQL_BIN_LOG::rotate(bool force_rotate, bool *check_purge) {
   if (DBUG_EVALUATE_IF("force_rotate", 1, 0) || force_rotate ||
       (m_binlog_file->get_real_file_size() >= (my_off_t)max_size) ||
       DBUG_EVALUATE_IF("simulate_max_binlog_size", true, false)) {
-    error = new_file_without_locking(nullptr);
-
+    error = new_file_without_locking(nullptr, try_lock_index);
+    if (try_lock_index && error == TRY_LOCK_INDEX_FAIL) {
+      DEBUG_SYNC(current_thd, "txsql_try_lock_index_failed");
+      return 0;
+    }
     if (cdb_page_cache_cleaning_binlog) {
       progress_tracker.update_active_file(log_file_name);
       progress_tracker.make_progress();
@@ -9315,13 +9374,25 @@ void MYSQL_BIN_LOG::rotate_after_commit(THD *thd) {
   */
   DEBUG_SYNC(thd, "ready_to_do_rotation");
   bool check_purge = false;
-  mysql_mutex_lock(&LOCK_log);
-  /*
-    If rotate fails then depends on binlog_error_action variable
-    appropriate action will be taken inside rotate call.
-  */
-  int error = rotate(false, &check_purge);
-  mysql_mutex_unlock(&LOCK_log);
+  int error = 0;
+  bool lock_log_locked = true;
+  if (txsql_binlog_rotate_try_lock_log) {
+    error = mysql_mutex_trylock(&LOCK_log);
+    if (error != 0) {
+      lock_log_locked = false;
+      error = 0;
+    }
+  } else {
+    mysql_mutex_lock(&LOCK_log);
+  }
+  if (lock_log_locked) {
+    /*
+      If rotate fails then depends on binlog_error_action variable
+      appropriate action will be taken inside rotate call.
+    */
+    error = rotate(false, &check_purge, txsql_binlog_rotate_try_lock_index);
+    mysql_mutex_unlock(&LOCK_log);
+  }
   if (error)
     thd->commit_error = THD::CE_COMMIT_ERROR;
   else if (check_purge)

--- a/sql/binlog.h
+++ b/sql/binlog.h
@@ -276,11 +276,13 @@ class MYSQL_BIN_LOG : public TC_LOG {
     LOCK_log.
   */
   int new_file_without_locking(
-      Format_description_log_event *extra_description_event);
+      Format_description_log_event *extra_description_event,
+      bool try_lock_index = false);
 
- private:
+private:
   int new_file_impl(bool need_lock,
-                    Format_description_log_event *extra_description_event);
+                    Format_description_log_event *extra_description_event,
+                    bool try_lock_index);
 
   bool open(PSI_file_key log_file_key, const char *log_name,
             const char *new_name, uint32 new_index_number);
@@ -433,7 +435,8 @@ class MYSQL_BIN_LOG : public TC_LOG {
                       bool verify_checksum, bool need_lock,
                       Transaction_boundary_parser *trx_parser,
                       Gtid_monitoring_info *partial_trx,
-                      bool is_server_starting = false);
+                      bool is_server_starting = false, bool add_log = false,
+                      ulonglong check_file_count = 0);
 
   void set_previous_gtid_set_relaylog(Gtid_set *previous_gtid_set_param) {
     assert(is_relay_log);
@@ -800,7 +803,7 @@ class MYSQL_BIN_LOG : public TC_LOG {
   void make_log_name(char *buf, const char *log_ident);
   bool is_active(const char *log_file_name);
   int remove_logs_from_index(LOG_INFO *linfo, bool need_update_threads);
-  int rotate(bool force_rotate, bool *check_purge);
+  int rotate(bool force_rotate, bool *check_purge, bool try_lock_index = false);
 
   /**
     @brief This function runs automatic purge if the conditions to meet
@@ -838,7 +841,7 @@ class MYSQL_BIN_LOG : public TC_LOG {
   bool flush_and_sync(const bool force = false);
   int purge_logs(const char *to_log, bool included, bool need_lock_index,
                  bool need_update_threads, ulonglong *decrease_log_space,
-                 bool auto_purge);
+                 bool auto_purge, ulonglong check_file_count = 0);
   int purge_logs_before_date(time_t purge_time, bool auto_purge);
   int set_crash_safe_index_file_name(const char *base_file_name);
   int open_crash_safe_index_file();
@@ -877,7 +880,7 @@ class MYSQL_BIN_LOG : public TC_LOG {
             the content of the log index file.
   */
   std::pair<int, std::list<std::string>> get_log_index(
-      bool need_lock_index = true);
+      bool need_lock_index = true, ulonglong file_count = 0);
   inline char *get_index_fname() { return index_file_name; }
   inline char *get_log_fname() { return log_file_name; }
   const char *get_name() const { return name; }
@@ -1216,6 +1219,9 @@ class MYSQL_BIN_LOG : public TC_LOG {
   };
   void update_progress_tracker_logfiles(bool reset_pointers = false);
   BIN_LOG_PROGRESS_TRACKER progress_tracker;
+
+ private:
+  static constexpr int TRY_LOCK_INDEX_FAIL = 12345;
 };
 
 struct LOAD_FILE_INFO {

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -1300,6 +1300,10 @@ bool opt_log_replica_updates = false;
 char *opt_replica_skip_errors;
 bool opt_replica_allow_batching = true;
 
+bool txsql_binlog_rotate_try_lock_index = false;
+bool txsql_binlog_rotate_try_lock_log = false;
+ulonglong txsql_binlog_purge_check_file_count = 0;
+
 bool txsql_audit_alter_table_enable= false;
 bool txsql_audit_set_option_enable= false;
 /**

--- a/sql/mysqld.h
+++ b/sql/mysqld.h
@@ -1048,5 +1048,9 @@ extern PSI_cond_key key_LOCK_page_cache_cleaning,
 extern PSI_mutex_key key_thread_os_page_cache_cleaning;
 extern mysql_mutex_t LOCK_page_cache_cleaning;
 
+extern bool txsql_binlog_rotate_try_lock_index;
+extern bool txsql_binlog_rotate_try_lock_log;
+extern ulonglong txsql_binlog_purge_check_file_count;
+
 /* Changes from txsql end. */
 #endif /* MYSQLD_INCLUDED */

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -2965,9 +2965,9 @@ static Sys_var_ulong Sys_max_binlog_size(
     "Binary log will be rotated automatically when the size exceeds this "
     "value. Will also apply to relay logs if max_relay_log_size is 0",
     GLOBAL_VAR(max_binlog_size), CMD_LINE(REQUIRED_ARG),
-    VALID_RANGE(IO_SIZE, 1024 * 1024L * 1024L), DEFAULT(1024 * 1024L * 1024L),
-    BLOCK_SIZE(IO_SIZE), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(nullptr),
-    ON_UPDATE(fix_max_binlog_size));
+    VALID_RANGE(IO_SIZE, 1024 * 1024L * 1024L * 10L),
+    DEFAULT(1024 * 1024L * 1024L), BLOCK_SIZE(IO_SIZE), NO_MUTEX_GUARD,
+    NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(fix_max_binlog_size));
 
 static Sys_var_ulong Sys_max_connections(
     "max_connections", "The number of simultaneous clients allowed",
@@ -4075,6 +4075,27 @@ static bool check_thread_handling(sys_var *, THD *, set_var *var) {
   }
   return false;
 }
+
+static Sys_var_bool Sys_txsql_binlog_rotate_try_lock_index(
+    "txsql_binlog_rotate_try_lock_index",
+    "If set to ON, binlog will not rotate if LOCK_index could not be acquired.",
+    GLOBAL_VAR(txsql_binlog_rotate_try_lock_index), CMD_LINE(OPT_ARG),
+    DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
+    ON_UPDATE(NULL));
+
+static Sys_var_bool Sys_txsql_binlog_rotate_try_lock_log(
+    "txsql_binlog_rotate_try_lock_log",
+    "If set to ON, binlog will not rotate if LOCK_log could not be acquired.",
+    GLOBAL_VAR(txsql_binlog_rotate_try_lock_log), CMD_LINE(OPT_ARG),
+    DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG, ON_CHECK(NULL),
+    ON_UPDATE(NULL));
+
+static Sys_var_ulonglong Sys_txsql_binlog_purge_check_file_count(
+    "txsql_binlog_purge_check_file_count",
+    "Check how many binlog files to get lost gtids during purge.",
+    GLOBAL_VAR(txsql_binlog_purge_check_file_count), CMD_LINE(OPT_ARG),
+    VALID_RANGE(0, ULONG_MAX), DEFAULT(0), BLOCK_SIZE(1), NO_MUTEX_GUARD,
+    NOT_IN_BINLOG, ON_CHECK(nullptr), ON_UPDATE(nullptr));
 /* Changes from txsql end. */
 
 static Sys_var_enum Sys_thread_handling(


### PR DESCRIPTION
Description:
===========
Binlog rotate could not acquire LOCK_index if binlog purge is running, which may block subsequent transactions for a long time. To solve this problem, we use try_lock instead of lock to acquire LOCK_index. If LOCK_index is being used by other threads, we will give up binlog rotate and try rotating next time.