### PR TITLE
Bug#86 Fix uninitialized value

### DIFF
--- a/storage/innobase/ddl/ddl0fts.cc
+++ b/storage/innobase/ddl/ddl0fts.cc
@@ -454,6 +454,7 @@ dict_index_t *FTS::create_index(dict_index_t *index, dict_table_t *table,
       mem_heap_alloc(new_index->heap, sizeof(dict_col_t)));
 
   field->col->old_mtype = DATA_MTYPE_MAX;
+  field->col->modified_version = 0;
   field->col->len = FTS_MAX_WORD_LEN;
 
   field->col->mtype =
@@ -477,6 +478,7 @@ dict_index_t *FTS::create_index(dict_index_t *index, dict_table_t *table,
 
   field->col->mtype = DATA_INT;
   field->col->old_mtype = DATA_MTYPE_MAX;
+  field->col->modified_version = 0;
   *doc_id_32_bit = false;
 
   /* Check whether we can use 4 bytes instead of 8 bytes integer
@@ -525,6 +527,7 @@ dict_index_t *FTS::create_index(dict_index_t *index, dict_table_t *table,
 
   field->col->mtype = DATA_INT;
   field->col->old_mtype = DATA_MTYPE_MAX;
+  field->col->modified_version = 0;
 
   field->col->len = 4;
   field->fixed_len = 4;


### PR DESCRIPTION
Problem:
========
Valgrind report uninitialized value while running case: instant_ddl_with_fts_index.

Solution:
=========
Init dict_col_t::modified_version in FTS::create_index.