### PR TITLE
[bugfix] issue#89 fix some bugs of compressed column

### DIFF
--- a/mysql-test/suite/innodb/r/compressed_columns_basic.result
+++ b/mysql-test/suite/innodb/r/compressed_columns_basic.result
@@ -634,3 +634,62 @@ CREATE TABLE t1 (c1 VARBINARY(5) COLUMN_FORMAT COMPRESSED) ENGINE=InnoDB;
 ALTER TABLE t1 ADD c2 CHAR(10) FIRST;
 INSERT INTO t1 VALUES(0,11111);
 DROP TABLE t1;
+#
+# Bug issue#1518 compresse blob free heap bug
+#
+SET GLOBAL innodb_min_column_compress_length = 1;
+CREATE TABLE `col_compress1` (
+`id` int NOT NULL AUTO_INCREMENT,
+`col_varchar` varchar(255) /*!80022 COMPRESSED ALGORITHM=ZLIB */ DEFAULT 'varchar_columnaaaaabbbbbccccc',
+`col_varbinary` varbinary(255) /*!80022 COMPRESSED ALGORITHM=ZLIB */ DEFAULT 'varbinary_columnaaaaabbbbbccccc',
+`col_tinyblob` tinyblob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_mediumblob` mediumblob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_blob` blob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_longblob` longblob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_tinytext` tinytext /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_mediumtext` mediumtext /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_text` text /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_longtext` longtext /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_json` json /*!80022 COMPRESSED ALGORITHM=ZLIB */ DEFAULT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1002;
+INSERT INTO col_compress1 VALUES 
+(1001,'abcdefghijklmnopqrstuvwxyzABCDEFGHIJ啊阿埃>挨哎唉哀皑癌蔼矮艾KLMNOPQRSTUVWXYZ0123456789!@#$%^&*abc碍爱隘鞍氨安俺按暗岸胺案',
+'abcdefghijklmnopqrstuvw啊阿埃挨哎唉哀xyzABCDEFGHIJKLMNOPQRST皑癌蔼矮艾碍爱隘',
+'abcdefghijklmnopqrstuvwxyzA啊阿埃挨哎唉哀皑癌BCDEFGHIJKLMNOPQRSTUVWXYZ01蔼矮艾碍爱隘鞍氨安',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘鞍氨安俺按9
+!@#$%^&*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ暗岸胺案肮昂盎凹敖熬翱袄傲奥懊澳芭捌扒叭',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘UVWXYZ0123456789!@#$%^&*abcdefghijklmnopqrstuvw鞍氨安俺按暗岸胺案肮昂盎凹敖熬翱',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘鞍氨
+安456789!@#$%^&*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ俺按暗岸胺案肮昂盎凹敖熬翱袄傲奥懊澳芭',
+'abcdefghijklmnopqrstuvwxyzA啊阿埃挨哎唉哀皑癌BCDEFGHIJKLMNOPQRSTUVWXYZ012蔼矮艾碍爱隘鞍氨安',
+'abcdefghijklmnopqrstuvwx啊阿埃挨哎唉哀皑yzABCDEFGHIJKLMNOPQRSTUVW癌蔼矮艾碍爱隘鞍',
+'abcdefghijklmnop啊阿埃挨哎qrstuvwxyzABCDEFG唉哀皑癌蔼矮',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR啊阿埃挨哎唉哀皑癌蔼矮艾碍爱STUVWXYZ0123456789!@#$%^&*abcdefghijklmnopqrs隘鞍氨安俺按暗岸胺案肮昂盎凹敖',
+'{\"key_0\": \"4092196619\", \"key_1\": \"9498253770\", \"key_2\": \"7844555836\", \"key_3\": \"7497657238\", \"key_4\": \"6776890143\", 
+\"key_5\": \"4748119599\", \"key_6\": \"7884453552\", \"key_7\": \"3269203856\", \"key_8\": \"8200776478\", \"key_9\": \"1536659817\", 
+\"key_10\": \"8303541107\", \"key_11\": \"8620459145\", \"key_12\": \"2851246775\", \"key_13\": \"5907220761\", \"key_14\": \"0114612178\", 
+\"key_15\": \"8739063082\", \"key_16\": \"5135810508\", \"key_17\": \"3972092994\", \"key_18\": \"2216259864\", \"key_19\": \"8552632056\", 
+\"key_20\": \"2533632090\", \"key_21\": \"4751478304\", \"key_22\": \"1371594488\", \"key_23\": \"6935895504\", \"key_24\": \"3795362665\", 
+\"key_25\": \"5638838421\", \"key_26\": \"8685413962\", \"key_27\": \"1142940613\", \"key_28\": \"6611162437\", \"key_29\": \"7814855780\", 
+\"key_30\": \"2797715785\", \"key_31\": \"4717629994\", \"key_32\": \"1708550312\", \"key_33\": \"8845848033\", \"key_34\": \"6131889006\", 
+\"key_35\": \"7401906955\", \"key_36\": \"7615307979\", \"key_37\": \"9701896248\", \"key_38\": \"6690866528\", \"key_39\": \"4812011891\", 
+\"key_40\": \"6833598289\", \"key_41\": \"7799643064\", \"key_42\": \"9906332853\", \"key_43\": \"6424750190\", \"key_44\": \"9479189693\", 
+\"key_45\": \"5540540987\", \"key_46\": \"1483812525\", \"key_47\": \"8399618192\", \"key_48\": \"0441694157\", \"key_49\": \"3384890443\", 
+\"key_50\": \"8355068400\", \"key_51\": \"1197712803\", \"key_52\": \"7058073002\", \"key_53\": \"2588539223\", \"key_54\": \"4824871485\", 
+\"key_55\": \"3355594857\", \"key_56\": \"7629977897\", \"key_57\": \"8453583314\", \"key_58\": \"5666893954\", \"key_59\": \"7268205520\", 
+\"key_60\": \"7290668398\", \"key_61\": \"0744762049\", \"key_62\": \"9614034887\", \"key_63\": \"3450903932\", \"key_64\": \"2562458497\", 
+\"key_65\": \"6210122826\", \"key_66\": \"2746372659\", \"key_67\": \"8583157278\", \"key_68\": \"3924555449\", \"key_69\": \"6688060801\", 
+\"key_70\": \"3270361775\", \"key_71\": \"9105998746\", \"key_72\": \"2807366073\", \"key_73\": \"3365782244\", \"key_74\": \"5722155614\", 
+\"key_75\": \"4539418662\", \"key_76\": \"0607207467\", \"key_77\": \"8193911800\", \"key_78\": \"9726187890\", \"key_79\": \"4545785968\", 
+\"key_80\": \"3921422978\", \"key_81\": \"2065863769\", \"key_82\": \"4905837869\", \"key_83\": \"4082476229\", \"key_84\": \"1498886667\", 
+\"key_85\": \"0462485216\", \"key_86\": \"2024355615\", \"key_87\": \"1690968133\", \"key_88\": \"3292731941\", \"key_89\": \"7094345233\", 
+\"key_90\": \"8588988711\", \"key_91\": \"5990845512\", \"key_92\": \"9663122362\", \"key_93\": \"2951971697\", \"key_94\": \"7994735356\", 
+\"key_95\": \"0341549135\", \"key_96\": \"4238814469\"}');
+select * from col_compress1;
+id	col_varchar	col_varbinary	col_tinyblob	col_mediumblob	col_blob	col_longblob	col_tinytext	col_mediumtext	col_text	col_longtext	col_json
+1001	abcdefghijklmnopqrstuvwxyzABCDEFGHIJ啊阿埃>挨哎唉哀皑癌蔼矮艾KLMNOPQRSTUVWXYZ0123456789!@#$%^&*abc碍爱隘鞍氨安俺按暗岸胺案	abcdefghijklmnopqrstuvw啊阿埃挨哎唉哀xyzABCDEFGHIJKLMNOPQRST皑癌蔼矮艾碍爱隘	abcdefghijklmnopqrstuvwxyzA啊阿埃挨哎唉哀皑癌BCDEFGHIJKLMNOPQRSTUVWXYZ01蔼矮艾碍爱隘鞍氨安	abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘鞍氨安俺按9
+!@#$%^&*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ暗岸胺案肮昂盎凹敖熬翱袄傲奥懊澳芭捌扒叭	abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘UVWXYZ0123456789!@#$%^&*abcdefghijklmnopqrstuvw鞍氨安俺按暗岸胺案肮昂盎凹敖熬翱	abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘鞍氨
+安456789!@#$%^&*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ俺按暗岸胺案肮昂盎凹敖熬翱袄傲奥懊澳芭	abcdefghijklmnopqrstuvwxyzA啊阿埃挨哎唉哀皑癌BCDEFGHIJKLMNOPQRSTUVWXYZ012蔼矮艾碍爱隘鞍氨安	abcdefghijklmnopqrstuvwx啊阿埃挨哎唉哀皑yzABCDEFGHIJKLMNOPQRSTUVW癌蔼矮艾碍爱隘鞍	abcdefghijklmnop啊阿埃挨哎qrstuvwxyzABCDEFG唉哀皑癌蔼矮	abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR啊阿埃挨哎唉哀皑癌蔼矮艾碍爱STUVWXYZ0123456789!@#$%^&*abcdefghijklmnopqrs隘鞍氨安俺按暗岸胺案肮昂盎凹敖	{"key_0": "4092196619", "key_1": "9498253770", "key_2": "7844555836", "key_3": "7497657238", "key_4": "6776890143", "key_5": "4748119599", "key_6": "7884453552", "key_7": "3269203856", "key_8": "8200776478", "key_9": "1536659817", "key_10": "8303541107", "key_11": "8620459145", "key_12": "2851246775", "key_13": "5907220761", "key_14": "0114612178", "key_15": "8739063082", "key_16": "5135810508", "key_17": "3972092994", "key_18": "2216259864", "key_19": "8552632056", "key_20": "2533632090", "key_21": "4751478304", "key_22": "1371594488", "key_23": "6935895504", "key_24": "3795362665", "key_25": "5638838421", "key_26": "8685413962", "key_27": "1142940613", "key_28": "6611162437", "key_29": "7814855780", "key_30": "2797715785", "key_31": "4717629994", "key_32": "1708550312", "key_33": "8845848033", "key_34": "6131889006", "key_35": "7401906955", "key_36": "7615307979", "key_37": "9701896248", "key_38": "6690866528", "key_39": "4812011891", "key_40": "6833598289", "key_41": "7799643064", "key_42": "9906332853", "key_43": "6424750190", "key_44": "9479189693", "key_45": "5540540987", "key_46": "1483812525", "key_47": "8399618192", "key_48": "0441694157", "key_49": "3384890443", "key_50": "8355068400", "key_51": "1197712803", "key_52": "7058073002", "key_53": "2588539223", "key_54": "4824871485", "key_55": "3355594857", "key_56": "7629977897", "key_57": "8453583314", "key_58": "5666893954", "key_59": "7268205520", "key_60": "7290668398", "key_61": "0744762049", "key_62": "9614034887", "key_63": "3450903932", "key_64": "2562458497", "key_65": "6210122826", "key_66": "2746372659", "key_67": "8583157278", "key_68": "3924555449", "key_69": "6688060801", "key_70": "3270361775", "key_71": "9105998746", "key_72": "2807366073", "key_73": "3365782244", "key_74": "5722155614", "key_75": "4539418662", "key_76": "0607207467", "key_77": "8193911800", "key_78": "9726187890", "key_79": "4545785968", "key_80": "3921422978", "key_81": "2065863769", "key_82": "4905837869", "key_83": "4082476229", "key_84": "1498886667", "key_85": "0462485216", "key_86": "2024355615", "key_87": "1690968133", "key_88": "3292731941", "key_89": "7094345233", "key_90": "8588988711", "key_91": "5990845512", "key_92": "9663122362", "key_93": "2951971697", "key_94": "7994735356", "key_95": "0341549135", "key_96": "4238814469"}
+drop table col_compress1;
+SET GLOBAL innodb_min_column_compress_length = @saved_innodb_min_column_compress_length;

--- a/mysql-test/suite/innodb/r/compressed_columns_multi_algo.result
+++ b/mysql-test/suite/innodb/r/compressed_columns_multi_algo.result
@@ -253,3 +253,151 @@ id	LEFT(a, 30)	LENGTH(a)
 1	barbarbarbarbarbarbarbarbarbar	750
 3	xyzxyzxyzxyzxyzxyzxyzxyzxyzxyz	900
 DROP TABLE t1;
+CREATE TABLE t1_json(
+id INT AUTO_INCREMENT PRIMARY KEY,
+json_column JSON COMPRESSED ALGORITHM = ZLIB
+);
+INSERT INTO t1_json (json_column) VALUES
+('{"key": "value 0"}'),
+('{"key": "value 1"}'),
+('{"key": "value 2"}'),
+('{"key": "value 3"}'),
+('{"key": "value 4"}'),
+('{"key": "value 5"}'),
+('{"key": "value 6"}'),
+('{"key": "value 7"}'),
+('{"key": "value 8"}'),
+('{"key": "value 9"}');
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB, ALGORITHM=INSTANT;
+ERROR 0A000: ALGORITHM=INSTANT is not supported. Reason: Need to rebuild the table to change column type. Try ALGORITHM=COPY/INPLACE.
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB;
+SELECT * FROM t1_json;
+id	json_column
+1	{"key": "value 0"}
+2	{"key": "value 1"}
+3	{"key": "value 2"}
+4	{"key": "value 3"}
+5	{"key": "value 4"}
+6	{"key": "value 5"}
+7	{"key": "value 6"}
+8	{"key": "value 7"}
+9	{"key": "value 8"}
+10	{"key": "value 9"}
+drop table t1_json;

--- a/mysql-test/suite/innodb/t/compressed_columns_basic.test
+++ b/mysql-test/suite/innodb/t/compressed_columns_basic.test
@@ -429,3 +429,64 @@ CREATE TABLE t1 (c1 VARBINARY(5) COLUMN_FORMAT COMPRESSED) ENGINE=InnoDB;
 ALTER TABLE t1 ADD c2 CHAR(10) FIRST;
 INSERT INTO t1 VALUES(0,11111);
 DROP TABLE t1;
+
+--echo #
+--echo # Bug issue#1518 compresse blob free heap bug
+--echo #
+
+SET GLOBAL innodb_min_column_compress_length = 1;
+
+CREATE TABLE `col_compress1` (
+`id` int NOT NULL AUTO_INCREMENT,
+`col_varchar` varchar(255) /*!80022 COMPRESSED ALGORITHM=ZLIB */ DEFAULT 'varchar_columnaaaaabbbbbccccc',
+`col_varbinary` varbinary(255) /*!80022 COMPRESSED ALGORITHM=ZLIB */ DEFAULT 'varbinary_columnaaaaabbbbbccccc',
+`col_tinyblob` tinyblob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_mediumblob` mediumblob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_blob` blob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_longblob` longblob /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_tinytext` tinytext /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_mediumtext` mediumtext /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_text` text /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_longtext` longtext /*!80022 COMPRESSED ALGORITHM=ZLIB */,
+`col_json` json /*!80022 COMPRESSED ALGORITHM=ZLIB */ DEFAULT NULL,
+PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=1002;
+
+INSERT INTO col_compress1 VALUES 
+(1001,'abcdefghijklmnopqrstuvwxyzABCDEFGHIJ啊阿埃>挨哎唉哀皑癌蔼矮艾KLMNOPQRSTUVWXYZ0123456789!@#$%^&*abc碍爱隘鞍氨安俺按暗岸胺案',
+'abcdefghijklmnopqrstuvw啊阿埃挨哎唉哀xyzABCDEFGHIJKLMNOPQRST皑癌蔼矮艾碍爱隘',
+'abcdefghijklmnopqrstuvwxyzA啊阿埃挨哎唉哀皑癌BCDEFGHIJKLMNOPQRSTUVWXYZ01蔼矮艾碍爱隘鞍氨安',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345678啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘鞍氨安俺按9
+!@#$%^&*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ暗岸胺案肮昂盎凹敖熬翱袄傲奥懊澳芭捌扒叭',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRST啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘UVWXYZ0123456789!@#$%^&*abcdefghijklmnopqrstuvw鞍氨安俺按暗岸胺案肮昂盎凹敖熬翱',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123啊阿埃挨哎唉哀皑癌蔼矮艾碍爱隘鞍氨
+安456789!@#$%^&*abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQ俺按暗岸胺案肮昂盎凹敖熬翱袄傲奥懊澳芭',
+'abcdefghijklmnopqrstuvwxyzA啊阿埃挨哎唉哀皑癌BCDEFGHIJKLMNOPQRSTUVWXYZ012蔼矮艾碍爱隘鞍氨安',
+'abcdefghijklmnopqrstuvwx啊阿埃挨哎唉哀皑yzABCDEFGHIJKLMNOPQRSTUVW癌蔼矮艾碍爱隘鞍',
+'abcdefghijklmnop啊阿埃挨哎qrstuvwxyzABCDEFG唉哀皑癌蔼矮',
+'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR啊阿埃挨哎唉哀皑癌蔼矮艾碍爱STUVWXYZ0123456789!@#$%^&*abcdefghijklmnopqrs隘鞍氨安俺按暗岸胺案肮昂盎凹敖',
+'{\"key_0\": \"4092196619\", \"key_1\": \"9498253770\", \"key_2\": \"7844555836\", \"key_3\": \"7497657238\", \"key_4\": \"6776890143\", 
+\"key_5\": \"4748119599\", \"key_6\": \"7884453552\", \"key_7\": \"3269203856\", \"key_8\": \"8200776478\", \"key_9\": \"1536659817\", 
+\"key_10\": \"8303541107\", \"key_11\": \"8620459145\", \"key_12\": \"2851246775\", \"key_13\": \"5907220761\", \"key_14\": \"0114612178\", 
+\"key_15\": \"8739063082\", \"key_16\": \"5135810508\", \"key_17\": \"3972092994\", \"key_18\": \"2216259864\", \"key_19\": \"8552632056\", 
+\"key_20\": \"2533632090\", \"key_21\": \"4751478304\", \"key_22\": \"1371594488\", \"key_23\": \"6935895504\", \"key_24\": \"3795362665\", 
+\"key_25\": \"5638838421\", \"key_26\": \"8685413962\", \"key_27\": \"1142940613\", \"key_28\": \"6611162437\", \"key_29\": \"7814855780\", 
+\"key_30\": \"2797715785\", \"key_31\": \"4717629994\", \"key_32\": \"1708550312\", \"key_33\": \"8845848033\", \"key_34\": \"6131889006\", 
+\"key_35\": \"7401906955\", \"key_36\": \"7615307979\", \"key_37\": \"9701896248\", \"key_38\": \"6690866528\", \"key_39\": \"4812011891\", 
+\"key_40\": \"6833598289\", \"key_41\": \"7799643064\", \"key_42\": \"9906332853\", \"key_43\": \"6424750190\", \"key_44\": \"9479189693\", 
+\"key_45\": \"5540540987\", \"key_46\": \"1483812525\", \"key_47\": \"8399618192\", \"key_48\": \"0441694157\", \"key_49\": \"3384890443\", 
+\"key_50\": \"8355068400\", \"key_51\": \"1197712803\", \"key_52\": \"7058073002\", \"key_53\": \"2588539223\", \"key_54\": \"4824871485\", 
+\"key_55\": \"3355594857\", \"key_56\": \"7629977897\", \"key_57\": \"8453583314\", \"key_58\": \"5666893954\", \"key_59\": \"7268205520\", 
+\"key_60\": \"7290668398\", \"key_61\": \"0744762049\", \"key_62\": \"9614034887\", \"key_63\": \"3450903932\", \"key_64\": \"2562458497\", 
+\"key_65\": \"6210122826\", \"key_66\": \"2746372659\", \"key_67\": \"8583157278\", \"key_68\": \"3924555449\", \"key_69\": \"6688060801\", 
+\"key_70\": \"3270361775\", \"key_71\": \"9105998746\", \"key_72\": \"2807366073\", \"key_73\": \"3365782244\", \"key_74\": \"5722155614\", 
+\"key_75\": \"4539418662\", \"key_76\": \"0607207467\", \"key_77\": \"8193911800\", \"key_78\": \"9726187890\", \"key_79\": \"4545785968\", 
+\"key_80\": \"3921422978\", \"key_81\": \"2065863769\", \"key_82\": \"4905837869\", \"key_83\": \"4082476229\", \"key_84\": \"1498886667\", 
+\"key_85\": \"0462485216\", \"key_86\": \"2024355615\", \"key_87\": \"1690968133\", \"key_88\": \"3292731941\", \"key_89\": \"7094345233\", 
+\"key_90\": \"8588988711\", \"key_91\": \"5990845512\", \"key_92\": \"9663122362\", \"key_93\": \"2951971697\", \"key_94\": \"7994735356\", 
+\"key_95\": \"0341549135\", \"key_96\": \"4238814469\"}');
+
+select * from col_compress1;
+
+drop table col_compress1; 
+SET GLOBAL innodb_min_column_compress_length = @saved_innodb_min_column_compress_length;

--- a/mysql-test/suite/innodb/t/compressed_columns_multi_algo.test
+++ b/mysql-test/suite/innodb/t/compressed_columns_multi_algo.test
@@ -37,15 +37,73 @@ DROP TABLE t1;
 --let $algorithm_type = ZSTD
 --source suite/innodb/include/compressed_columns_multi_algo.inc
 
+#
 # multiple algorithm alteration tests
-# ZLIB to LZ4
+#
+CREATE TABLE t1_json(
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    json_column JSON COMPRESSED ALGORITHM = ZLIB
+);
+INSERT INTO t1_json (json_column) VALUES
+('{"key": "value 0"}'),
+('{"key": "value 1"}'),
+('{"key": "value 2"}'),
+('{"key": "value 3"}'),
+('{"key": "value 4"}'),
+('{"key": "value 5"}'),
+('{"key": "value 6"}'),
+('{"key": "value 7"}'),
+('{"key": "value 8"}'),
+('{"key": "value 9"}');
 
-# ZLIB to ZSTD
+SELECT * FROM t1_json;
+
+# ZLIB to LZ4
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4;
+SELECT * FROM t1_json;
 
 # LZ4 to ZLIB
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB;
+SELECT * FROM t1_json;
 
-# LZ4 to ZSTD
-
-# ZSTD to ZLIB
+# ZLIB to ZSTD
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD;
+SELECT * FROM t1_json;
 
 # ZSTD to LZ4
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = LZ4;
+SELECT * FROM t1_json;
+
+# LZ4 to ZSTD
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZSTD;
+SELECT * FROM t1_json;
+
+# ZSTD to ZLIB
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB;
+SELECT * FROM t1_json;
+
+# ZLIB to NULL
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON;
+SELECT * FROM t1_json;
+
+# NULL to ZLIB
+--error 1846
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB, ALGORITHM=INSTANT;
+ALTER TABLE t1_json MODIFY json_column JSON COMPRESSED ALGORITHM = ZLIB;
+SELECT * FROM t1_json;
+
+drop table t1_json;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -7670,7 +7670,10 @@ Field_json *Field_json::clone(MEM_ROOT *mem_root) const {
   @return true if new_field is compatible with this field, false otherwise
 */
 uint Field_json::is_equal(const Create_field *new_field) const {
-  // All JSON fields are compatible with each other.
+
+  if (has_different_compression_attributes_with(*new_field))
+    return IS_EQUAL_NO;
+
   return (new_field->sql_type == real_type());
 }
 

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -19676,6 +19676,10 @@ int ha_innobase::end_stmt() {
     row_mysql_prebuilt_free_blob_heap(m_prebuilt);
   }
 
+  if (m_prebuilt->compress_heap) {
+    row_mysql_prebuilt_free_compress_heap(m_prebuilt);
+  }
+
   m_prebuilt->end_stmt();
 
   reset_template();

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -835,7 +835,7 @@ do_not_compress:
   column_set_compress_header(ptr, false, 0,
                              ZLIB_COL_COMP);
   ptr += zip_column_header_length;
-  memcpy(ptr, data, *len);
+  memcpy(ptr, data, original_len);
   *len = original_len + zip_column_header_length;
   return buf;
 }

--- a/storage/innobase/row/row0sel.cc
+++ b/storage/innobase/row/row0sel.cc
@@ -3007,9 +3007,6 @@ void row_sel_field_store_in_mysql_format_func(
     if (UNIV_LIKELY_NULL(prebuilt->encryption_heap))
       mem_heap_empty(prebuilt->encryption_heap);
 
-    if (UNIV_LIKELY_NULL(prebuilt->compress_heap)) {
-      mem_heap_empty(prebuilt->compress_heap);
-    }
 
     /* Reassign the clustered index field no. */
     if (clust_templ_for_sec) {


### PR DESCRIPTION
Problem1:
Every time before row_sel_field_store_in_mysql_format, prebuilt->compress_heap will be cleared, but the decompressed data is saved in the heap, and only the pointer to the decompressed data is saved in the filed item. The protocol will send the tuple together after getting all the field data. Therefore, the data content sent during Field::send_to_protocol has been overwritten and corrupted.

Solution1:
Delete the operation of clearing the heap before each row_sel_field_store_in_mysql_format. The compressed heap is cleared before reading each tuple in row_sel_store_mysql_rec and also in stmt ends.

Problem2:
Alter compressed json column to no compressed or other algorithm use inpace instant alter make column corruption.

Solution2:
Prevents the use of instant alter when changes json column compress format.

Problem3:
When saving a compressed column, find the maximum threshold of the original length and try to compress it. However, the length reduced by compression is very small. After adding the meta information, the length is longer than the original length. In this case, no compression will be chosen. There is a bug with the code processing here. The compressed length is passed to memcpy (it should be original length), resulting in the loss of a few bytes of data at the end.

Solution3:
In this case, use the correct original length.

Problem4:
prebuilt->compress_heap was made empty but was not free at end_stmt.

Solution4:
use mem_heap_free to free prebuilt->compress_heap.