### PR TITLE
[feature] Implicit conversion of view that are referenced multiple ti…

### DIFF
--- a/mysql-test/r/view_to_cte.pq
+++ b/mysql-test/r/view_to_cte.pq
@@ -1,0 +1,1240 @@
+set @saved_value = @@txsql_convert_view_to_cte_enabled;
+create table t1 (a int, b int);
+insert into t1 values (1,2), (1,3), (2,4), (2,5), (3,10);
+create view simple_view as
+select * from t1;
+create view complex_view as
+select b from t1 group by b;
+create view complex_view_2 as
+select b+1 from t1 group by b+1;
+create view complex_view_3 as
+select b from t1 group by b;
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from complex_view as d_1, complex_view_3 as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE txsql cte if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view_3 as d_2;
+b	b
+10	10
+10	2
+10	3
+10	4
+10	5
+2	10
+2	2
+2	3
+2	4
+2	5
+3	10
+3	2
+3	3
+3	4
+3	5
+4	10
+4	2
+4	3
+4	4
+4	5
+5	10
+5	2
+5	3
+5	4
+5	5
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from complex_view as d_1, complex_view_2 as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+                        -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+                            -> Parallel table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view_2 as d_2;
+b	b+1
+10	11
+10	3
+10	4
+10	5
+10	6
+2	11
+2	3
+2	4
+2	5
+2	6
+3	11
+3	3
+3	4
+3	5
+3	6
+4	11
+4	3
+4	4
+4	5
+4	6
+5	11
+5	3
+5	4
+5	5
+5	6
+create view uncacheable_view as
+select b,rand() from t1 group by b;
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from uncacheable_view as d_1, uncacheable_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+                        -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+                            -> Parallel table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from uncacheable_view as d_1, uncacheable_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE txsql cte if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+drop view uncacheable_view;
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from simple_view;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+    -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+        -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view;
+a	b
+1	2
+1	3
+2	4
+2	5
+3	10
+explain format=tree select * from complex_view;
+EXPLAIN
+-> Table scan on complex_view  (cost=0.51..2.56 rows=5)
+    -> Materialize  (cost=4.83..6.88 rows=5)
+        -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+            -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                -> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+                    -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+                        -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view;
+b
+10
+2
+3
+4
+5
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from simple_view;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+    -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+        -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view;
+a	b
+1	2
+1	3
+2	4
+2	5
+3	10
+explain format=tree select * from complex_view;
+EXPLAIN
+-> Table scan on complex_view  (cost=0.51..2.56 rows=5)
+    -> Materialize  (cost=4.83..6.88 rows=5)
+        -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+            -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                -> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+                    -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+                        -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view;
+b
+10
+2
+3
+4
+5
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=3.50 rows=25)
+    -> PX Sender (slice: 1; workers: 4)  (cost=3.50 rows=25)
+        -> Inner hash join (no condition)  (cost=3.50 rows=25)
+            -> Parallel table scan on t1  (cost=0.15 rows=5)
+            -> Hash
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+1	2	1	2
+1	2	1	3
+1	2	2	4
+1	2	2	5
+1	2	3	10
+1	3	1	2
+1	3	1	3
+1	3	2	4
+1	3	2	5
+1	3	3	10
+2	4	1	2
+2	4	1	3
+2	4	2	4
+2	4	2	5
+2	4	3	10
+2	5	1	2
+2	5	1	3
+2	5	2	4
+2	5	2	5
+2	5	3	10
+3	10	1	2
+3	10	1	3
+3	10	2	4
+3	10	2	5
+3	10	3	10
+explain format=tree select * from complex_view as d_1, complex_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+                        -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+                            -> Parallel table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view as d_2;
+b	b
+10	10
+10	2
+10	3
+10	4
+10	5
+2	10
+2	2
+2	3
+2	4
+2	5
+3	10
+3	2
+3	3
+3	4
+3	5
+4	10
+4	2
+4	3
+4	4
+4	5
+5	10
+5	2
+5	3
+5	4
+5	5
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=3.50 rows=25)
+    -> PX Sender (slice: 1; workers: 4)  (cost=3.50 rows=25)
+        -> Inner hash join (no condition)  (cost=3.50 rows=25)
+            -> Parallel table scan on t1  (cost=0.15 rows=5)
+            -> Hash
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+1	2	1	2
+1	2	1	3
+1	2	2	4
+1	2	2	5
+1	2	3	10
+1	3	1	2
+1	3	1	3
+1	3	2	4
+1	3	2	5
+1	3	3	10
+2	4	1	2
+2	4	1	3
+2	4	2	4
+2	4	2	5
+2	4	3	10
+2	5	1	2
+2	5	1	3
+2	5	2	4
+2	5	2	5
+2	5	3	10
+3	10	1	2
+3	10	1	3
+3	10	2	4
+3	10	2	5
+3	10	3	10
+explain format=tree select * from complex_view as d_1, complex_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE txsql cte if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view as d_2;
+b	b
+10	10
+10	2
+10	3
+10	4
+10	5
+2	10
+2	2
+2	3
+2	4
+2	5
+3	10
+3	2
+3	3
+3	4
+3	5
+4	10
+4	2
+4	3
+4	4
+4	5
+5	10
+5	2
+5	3
+5	4
+5	5
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from (select * from t1) as d_1, (select * from t1) as d_2;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=3.50 rows=25)
+    -> PX Sender (slice: 1; workers: 4)  (cost=3.50 rows=25)
+        -> Inner hash join (no condition)  (cost=3.50 rows=25)
+            -> Parallel table scan on t1  (cost=0.15 rows=5)
+            -> Hash
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from (select * from t1) as d_1, (select * from t1) as d_2;
+a	b	a	b
+1	2	1	2
+1	2	1	3
+1	2	2	4
+1	2	2	5
+1	2	3	10
+1	3	1	2
+1	3	1	3
+1	3	2	4
+1	3	2	5
+1	3	3	10
+2	4	1	2
+2	4	1	3
+2	4	2	4
+2	4	2	5
+2	4	3	10
+2	5	1	2
+2	5	1	3
+2	5	2	4
+2	5	2	5
+2	5	3	10
+3	10	1	2
+3	10	1	3
+3	10	2	4
+3	10	2	5
+3	10	3	10
+explain format=tree select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+                        -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+                            -> Parallel table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+b	b
+10	10
+10	2
+10	3
+10	4
+10	5
+2	10
+2	2
+2	3
+2	4
+2	5
+3	10
+3	2
+3	3
+3	4
+3	5
+4	10
+4	2
+4	3
+4	4
+4	5
+5	10
+5	2
+5	3
+5	4
+5	5
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from (select * from t1) as d_1, (select * from t1) as d_2;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=3.50 rows=25)
+    -> PX Sender (slice: 1; workers: 4)  (cost=3.50 rows=25)
+        -> Inner hash join (no condition)  (cost=3.50 rows=25)
+            -> Parallel table scan on t1  (cost=0.15 rows=5)
+            -> Hash
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from (select * from t1) as d_1, (select * from t1) as d_2;
+a	b	a	b
+1	2	1	2
+1	2	1	3
+1	2	2	4
+1	2	2	5
+1	2	3	10
+1	3	1	2
+1	3	1	3
+1	3	2	4
+1	3	2	5
+1	3	3	10
+2	4	1	2
+2	4	1	3
+2	4	2	4
+2	4	2	5
+2	4	3	10
+2	5	1	2
+2	5	1	3
+2	5	2	4
+2	5	2	5
+2	5	3	10
+3	10	1	2
+3	10	1	3
+3	10	2	4
+3	10	2	5
+3	10	3	10
+explain format=tree select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> PX Receiver (slice: 0; workers: 1)  (cost=0.75 rows=5)
+                        -> PX Sender (slice: 1; workers: 4)  (cost=0.75 rows=5)
+                            -> Parallel table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+b	b
+10	10
+10	2
+10	3
+10	4
+10	5
+2	10
+2	2
+2	3
+2	4
+2	5
+3	10
+3	2
+3	3
+3	4
+3	5
+4	10
+4	2
+4	3
+4	4
+4	5
+5	10
+5	2
+5	3
+5	4
+5	5
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree
+with simple_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=3.50 rows=25)
+    -> PX Sender (slice: 1; workers: 4)  (cost=3.50 rows=25)
+        -> Inner hash join (no condition)  (cost=3.50 rows=25)
+            -> Parallel table scan on t1  (cost=0.15 rows=5)
+            -> Hash
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+with complex_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+explain format=tree
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE simple_view if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE simple_view if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+b	b
+10	3
+4	3
+2	3
+5	3
+3	3
+10	5
+4	5
+2	5
+5	5
+3	5
+10	2
+4	2
+2	2
+5	2
+3	2
+10	4
+4	4
+2	4
+5	4
+3	4
+10	10
+4	10
+2	10
+5	10
+3	10
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree
+with simple_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> PX Receiver (slice: 0; workers: 1)  (cost=3.50 rows=25)
+    -> PX Sender (slice: 1; workers: 4)  (cost=3.50 rows=25)
+        -> Inner hash join (no condition)  (cost=3.50 rows=25)
+            -> Parallel table scan on t1  (cost=0.15 rows=5)
+            -> Hash
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+with complex_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+explain format=tree
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE simple_view if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE simple_view if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> PX Receiver (slice: 2; workers: 1)  (cost=0.75 rows=5)
+                            -> PX Sender (slice: 3; workers: 4)  (cost=0.75 rows=5)
+                                -> Parallel table scan on t1  (cost=0.75 rows=5)
+
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+b	b
+10	2
+4	2
+5	2
+3	2
+2	2
+10	3
+4	3
+5	3
+3	3
+2	3
+10	5
+4	5
+5	5
+3	5
+2	5
+10	4
+4	4
+5	4
+3	4
+2	4
+10	10
+4	10
+5	10
+3	10
+2	10
+# Load data ...
+# Create indexes ...
+# Analyze tables ...
+Table	Op	Msg_type	Msg_text
+test.customer	analyze	status	OK
+test.lineitem	analyze	status	OK
+test.nation	analyze	status	OK
+test.orders	analyze	status	OK
+test.part	analyze	status	OK
+test.partsupp	analyze	status	OK
+test.region	analyze	status	OK
+test.supplier	analyze	status	OK
+create view revenue0 (supplier_no, total_revenue) as
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey;
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=#..13.30 rows=10)
+                -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                    -> Materialize  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Final Aggregate using temporary table
+                                -> PX Receiver (slice: 0; workers: 1)
+                                    -> PX Sender (slice: 1; workers: 2)
+                                        -> Table scan on <temporary>
+                                            -> Aggregate using temporary table
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                            -> Materialize  (cost=#..2.50 rows=0)
+                                -> Table scan on <temporary>
+                                    -> Final Aggregate using temporary table
+                                        -> PX Receiver (slice: 2; workers: 1)
+                                            -> PX Sender (slice: 3; workers: 2)
+                                                -> Table scan on <temporary>
+                                                    -> Aggregate using temporary table
+                                                        -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=# rows=1)
+
+explain analyze select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (actual time=X...)
+                            -> Final Aggregate using temporary table  (actual time=X...)
+                                -> PX Receiver (slice: 0; workers: 1)  (actual time=X...)
+                                    -> PX Sender (slice: 1; workers: 2)  (actual time=X...)
+                                        -> Table scan on <temporary>  (actual time=X...)
+                                            -> Aggregate using temporary table  (actual time=X...)
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize  (cost=2.50..2.50 rows=0) (actual time=X...)
+                                -> Table scan on <temporary>  (actual time=X...)
+                                    -> Final Aggregate using temporary table  (actual time=X...)
+                                        -> PX Receiver (slice: 2; workers: 1)  (actual time=X...)
+                                            -> PX Sender (slice: 3; workers: 2)  (actual time=X...)
+                                                -> Table scan on <temporary>  (actual time=X...)
+                                                    -> Aggregate using temporary table  (actual time=X...)
+                                                        -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=#..13.30 rows=10)
+                -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                    -> Materialize CTE txsql cte if needed  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Final Aggregate using temporary table
+                                -> PX Receiver (slice: 0; workers: 1)
+                                    -> PX Sender (slice: 1; workers: 2)
+                                        -> Table scan on <temporary>
+                                            -> Aggregate using temporary table
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                            -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=#..2.50 rows=0)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=# rows=1)
+
+explain analyze select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize CTE txsql cte if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (actual time=X...)
+                            -> Final Aggregate using temporary table  (actual time=X...)
+                                -> PX Receiver (slice: 0; workers: 1)  (actual time=X...)
+                                    -> PX Sender (slice: 1; workers: 2)  (actual time=X...)
+                                        -> Table scan on <temporary>  (actual time=X...)
+                                            -> Aggregate using temporary table  (actual time=X...)
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize CTE txsql cte if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                                -> Table scan on <temporary>  (never executed)
+                                    -> Final Aggregate using temporary table  (never executed)
+                                        -> PX Receiver (slice: 0; workers: 0)  (never executed)
+                                            -> PX Sender (slice: 0; workers: 0)  (never executed)
+                                                -> Table scan on <temporary>  (never executed)
+                                                    -> Aggregate using temporary table  (never executed)
+                                                        -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (never executed)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=#..13.30 rows=10)
+                -> Table scan on t1  (cost=#..2.50 rows=0)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Final Aggregate using temporary table
+                                -> PX Receiver (slice: 2; workers: 1)
+                                    -> PX Sender (slice: 3; workers: 2)
+                                        -> Table scan on <temporary>
+                                            -> Aggregate using temporary table
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on t2  (cost=#..2.50 rows=0)
+                            -> Materialize CTE cte_revenue0 if needed (query plan printed elsewhere)  (cost=#..2.50 rows=0)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=# rows=1)
+
+explain analyze with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on t1  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (never executed)
+                            -> Final Aggregate using temporary table  (never executed)
+                                -> PX Receiver (slice: 0; workers: 0)  (never executed)
+                                    -> PX Sender (slice: 0; workers: 0)  (never executed)
+                                        -> Table scan on <temporary>  (never executed)
+                                            -> Aggregate using temporary table  (never executed)
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (never executed)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on t2  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize CTE cte_revenue0 if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                                -> Table scan on <temporary>  (actual time=X...)
+                                    -> Final Aggregate using temporary table  (actual time=X...)
+                                        -> PX Receiver (slice: 0; workers: 1)  (actual time=X...)
+                                            -> PX Sender (slice: 1; workers: 2)  (actual time=X...)
+                                                -> Table scan on <temporary>  (actual time=X...)
+                                                    -> Aggregate using temporary table  (actual time=X...)
+                                                        -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=#..13.30 rows=10)
+                -> Table scan on t1  (cost=#..2.50 rows=0)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Final Aggregate using temporary table
+                                -> PX Receiver (slice: 2; workers: 1)
+                                    -> PX Sender (slice: 3; workers: 2)
+                                        -> Table scan on <temporary>
+                                            -> Aggregate using temporary table
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on t2  (cost=#..2.50 rows=0)
+                            -> Materialize CTE cte_revenue0 if needed (query plan printed elsewhere)  (cost=#..2.50 rows=0)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=# rows=1)
+
+explain analyze with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on t1  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (never executed)
+                            -> Final Aggregate using temporary table  (never executed)
+                                -> PX Receiver (slice: 0; workers: 0)  (never executed)
+                                    -> PX Sender (slice: 0; workers: 0)  (never executed)
+                                        -> Table scan on <temporary>  (never executed)
+                                            -> Aggregate using temporary table  (never executed)
+                                                -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (never executed)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on t2  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize CTE cte_revenue0 if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                                -> Table scan on <temporary>  (actual time=X...)
+                                    -> Final Aggregate using temporary table  (actual time=X...)
+                                        -> PX Receiver (slice: 0; workers: 1)  (actual time=X...)
+                                            -> PX Sender (slice: 1; workers: 2)  (actual time=X...)
+                                                -> Table scan on <temporary>  (actual time=X...)
+                                                    -> Aggregate using temporary table  (actual time=X...)
+                                                        -> Parallel index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+drop table t1;
+drop view simple_view;
+drop view complex_view;
+drop view complex_view_2;
+drop view complex_view_3;
+drop view revenue0;
+#
+# Test end
+#
+# Cleanup, drop testing tables ...
+START TRANSACTION;
+drop TABLE lineitem;
+drop TABLE orders;
+drop TABLE partsupp;
+drop TABLE part;
+drop TABLE customer;
+drop TABLE supplier;
+drop TABLE nation;
+drop TABLE region;
+COMMIT;
+set @@txsql_convert_view_to_cte_enabled = @saved_value;

--- a/mysql-test/r/view_to_cte.result
+++ b/mysql-test/r/view_to_cte.result
@@ -1,0 +1,1129 @@
+set @saved_value = @@txsql_convert_view_to_cte_enabled;
+create table t1 (a int, b int);
+insert into t1 values (1,2), (1,3), (2,4), (2,5), (3,10);
+create view simple_view as
+select * from t1;
+create view complex_view as
+select b from t1 group by b;
+create view complex_view_2 as
+select b+1 from t1 group by b+1;
+create view complex_view_3 as
+select b from t1 group by b;
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from complex_view as d_1, complex_view_3 as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE txsql cte if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view_3 as d_2;
+b	b
+10	2
+5	2
+4	2
+3	2
+2	2
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	10
+5	10
+4	10
+3	10
+2	10
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from complex_view as d_1, complex_view_2 as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> Table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view_2 as d_2;
+b	b+1
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	6
+5	6
+4	6
+3	6
+2	6
+10	11
+5	11
+4	11
+3	11
+2	11
+create view uncacheable_view as
+select b,rand() from t1 group by b;
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from uncacheable_view as d_1, uncacheable_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> Table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from uncacheable_view as d_1, uncacheable_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE txsql cte if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+drop view uncacheable_view;
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from simple_view;
+EXPLAIN
+-> Table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view;
+a	b
+1	2
+1	3
+2	4
+2	5
+3	10
+explain format=tree select * from complex_view;
+EXPLAIN
+-> Table scan on complex_view  (cost=0.51..2.56 rows=5)
+    -> Materialize  (cost=4.83..6.88 rows=5)
+        -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+            -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view;
+b
+2
+3
+4
+5
+10
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from simple_view;
+EXPLAIN
+-> Table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view;
+a	b
+1	2
+1	3
+2	4
+2	5
+3	10
+explain format=tree select * from complex_view;
+EXPLAIN
+-> Table scan on complex_view  (cost=0.51..2.56 rows=5)
+    -> Materialize  (cost=4.83..6.88 rows=5)
+        -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+            -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view;
+b
+2
+3
+4
+5
+10
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=3.50 rows=25)
+    -> Table scan on t1  (cost=0.15 rows=5)
+    -> Hash
+        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+explain format=tree select * from complex_view as d_1, complex_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> Table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view as d_2;
+b	b
+10	2
+5	2
+4	2
+3	2
+2	2
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	10
+5	10
+4	10
+3	10
+2	10
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=3.50 rows=25)
+    -> Table scan on t1  (cost=0.15 rows=5)
+    -> Hash
+        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+explain format=tree select * from complex_view as d_1, complex_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE txsql cte if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from complex_view as d_1, complex_view as d_2;
+b	b
+10	2
+5	2
+4	2
+3	2
+2	2
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	10
+5	10
+4	10
+3	10
+2	10
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from (select * from t1) as d_1, (select * from t1) as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=3.50 rows=25)
+    -> Table scan on t1  (cost=0.15 rows=5)
+    -> Hash
+        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from (select * from t1) as d_1, (select * from t1) as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+explain format=tree select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> Table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+b	b
+10	2
+5	2
+4	2
+3	2
+2	2
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	10
+5	10
+4	10
+3	10
+2	10
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from (select * from t1) as d_1, (select * from t1) as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=3.50 rows=25)
+    -> Table scan on t1  (cost=0.15 rows=5)
+    -> Hash
+        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from (select * from t1) as d_1, (select * from t1) as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+explain format=tree select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize  (cost=4.83..6.88 rows=5)
+            -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                    -> Table scan on t1  (cost=0.75 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+b	b
+10	2
+5	2
+4	2
+3	2
+2	2
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	10
+5	10
+4	10
+3	10
+2	10
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree
+with simple_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=3.50 rows=25)
+    -> Table scan on t1  (cost=0.15 rows=5)
+    -> Hash
+        -> Table scan on t1  (cost=0.75 rows=5)
+
+with complex_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+explain format=tree
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE simple_view if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE simple_view if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+b	b
+10	2
+5	2
+4	2
+3	2
+2	2
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	10
+5	10
+4	10
+3	10
+2	10
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree
+with simple_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=3.50 rows=25)
+    -> Table scan on t1  (cost=0.15 rows=5)
+    -> Hash
+        -> Table scan on t1  (cost=0.75 rows=5)
+
+with complex_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+a	b	a	b
+3	10	1	2
+2	5	1	2
+2	4	1	2
+1	3	1	2
+1	2	1	2
+3	10	1	3
+2	5	1	3
+2	4	1	3
+1	3	1	3
+1	2	1	3
+3	10	2	4
+2	5	2	4
+2	4	2	4
+1	3	2	4
+1	2	2	4
+3	10	2	5
+2	5	2	5
+2	4	2	5
+1	3	2	5
+1	2	2	5
+3	10	3	10
+2	5	3	10
+2	4	3	10
+1	3	3	10
+1	2	3	10
+explain format=tree
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+EXPLAIN
+-> Inner hash join (no condition)  (cost=11.94 rows=25)
+    -> Table scan on d_2  (cost=0.51..2.56 rows=5)
+        -> Materialize CTE simple_view if needed (query plan printed elsewhere)  (cost=4.83..6.88 rows=5)
+    -> Hash
+        -> Table scan on d_1  (cost=0.51..2.56 rows=5)
+            -> Materialize CTE simple_view if needed  (cost=4.83..6.88 rows=5)
+                -> Table scan on <temporary>  (cost=0.51..2.56 rows=5)
+                    -> Temporary table with deduplication  (cost=1.76..3.81 rows=5)
+                        -> Table scan on t1  (cost=0.75 rows=5)
+
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+b	b
+10	2
+5	2
+4	2
+3	2
+2	2
+10	3
+5	3
+4	3
+3	3
+2	3
+10	4
+5	4
+4	4
+3	4
+2	4
+10	5
+5	5
+4	5
+3	5
+2	5
+10	10
+5	10
+4	10
+3	10
+2	10
+# Load data ...
+# Create indexes ...
+# Analyze tables ...
+Table	Op	Msg_type	Msg_text
+test.customer	analyze	status	OK
+test.lineitem	analyze	status	OK
+test.nation	analyze	status	OK
+test.orders	analyze	status	OK
+test.part	analyze	status	OK
+test.partsupp	analyze	status	OK
+test.region	analyze	status	OK
+test.supplier	analyze	status	OK
+create view revenue0 (supplier_no, total_revenue) as
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey;
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=#..13.30 rows=10)
+                -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                    -> Materialize  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Aggregate using temporary table
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                            -> Materialize  (cost=#..2.50 rows=0)
+                                -> Table scan on <temporary>
+                                    -> Aggregate using temporary table
+                                        -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=# rows=1)
+
+explain analyze select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (actual time=X...)
+                            -> Aggregate using temporary table  (actual time=X...)
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize  (cost=2.50..2.50 rows=0) (actual time=X...)
+                                -> Table scan on <temporary>  (actual time=X...)
+                                    -> Aggregate using temporary table  (actual time=X...)
+                                        -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=#..13.30 rows=10)
+                -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                    -> Materialize CTE txsql cte if needed  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Aggregate using temporary table
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on revenue0  (cost=#..2.50 rows=0)
+                            -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=#..2.50 rows=0)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=# rows=1)
+
+explain analyze select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (revenue0.total_revenue = (select #2))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize CTE txsql cte if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (actual time=X...)
+                            -> Aggregate using temporary table  (actual time=X...)
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+                -> Select #2 (subquery in condition; run only once)
+                    -> Aggregate: max(revenue0.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on revenue0  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize CTE txsql cte if needed (query plan printed elsewhere)  (cost=2.50..2.50 rows=0) (never executed)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=revenue0.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+revenue0
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+revenue0
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=#..13.30 rows=10)
+                -> Table scan on t1  (cost=#..2.50 rows=0)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Aggregate using temporary table
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on t2  (cost=#..2.50 rows=0)
+                            -> Materialize CTE cte_revenue0 if needed (query plan printed elsewhere)  (cost=#..2.50 rows=0)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=# rows=1)
+
+explain analyze with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on t1  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (actual time=X...)
+                            -> Aggregate using temporary table  (actual time=X...)
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on t2  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize CTE cte_revenue0 if needed (query plan printed elsewhere)  (cost=2.50..2.50 rows=0) (never executed)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey
+    -> Stream results  (cost=# rows=10)
+        -> Nested loop inner join  (cost=# rows=10)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=#..13.30 rows=10)
+                -> Table scan on t1  (cost=#..2.50 rows=0)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=#..2.50 rows=0)
+                        -> Table scan on <temporary>
+                            -> Aggregate using temporary table
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=# rows=96)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=#..2.50 rows=1)
+                        -> Table scan on t2  (cost=#..2.50 rows=0)
+                            -> Materialize CTE cte_revenue0 if needed (query plan printed elsewhere)  (cost=#..2.50 rows=0)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=# rows=1)
+
+explain analyze with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+EXPLAIN
+-> Sort: supplier.s_suppkey  (actual time=X...)
+    -> Stream results  (cost=16.66 rows=10) (actual time=X...)
+        -> Nested loop inner join  (cost=16.66 rows=10) (actual time=X...)
+            -> Filter: (t1.total_revenue = (select #3))  (cost=1.39..13.30 rows=10) (actual time=X...)
+                -> Table scan on t1  (cost=2.50..2.50 rows=0) (actual time=X...)
+                    -> Materialize CTE cte_revenue0 if needed  (cost=2.50..2.50 rows=0) (actual time=X...)
+                        -> Table scan on <temporary>  (actual time=X...)
+                            -> Aggregate using temporary table  (actual time=X...)
+                                -> Index range scan on lineitem using i_l_shipdate over ('1995-06-01' <= l_shipdate < '1995-08-30'), with index condition: ((lineitem.l_shipdate >= DATE'1995-06-01') and (lineitem.l_shipdate < <cache>(('1995-06-01' + interval '90' day))))  (cost=43.46 rows=96) (actual time=X...)
+                -> Select #3 (subquery in condition; run only once)
+                    -> Aggregate: max(t2.total_revenue)  (cost=2.50..2.50 rows=1) (actual time=X...)
+                        -> Table scan on t2  (cost=2.50..2.50 rows=0) (actual time=X...)
+                            -> Materialize CTE cte_revenue0 if needed (query plan printed elsewhere)  (cost=2.50..2.50 rows=0) (never executed)
+            -> Single-row index lookup on supplier using PRIMARY (s_suppkey=t1.supplier_no)  (cost=0.26 rows=1) (actual time=X...)
+
+with cte_revenue0 (supplier_no, total_revenue) as (
+select
+l_suppkey,
+sum(l_extendedprice * (1 - l_discount))
+from
+lineitem
+where
+l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+group by
+l_suppkey)
+select
+s_suppkey,
+s_name,
+s_address,
+s_phone,
+total_revenue
+from
+supplier,
+cte_revenue0 as t1
+where
+s_suppkey = supplier_no
+and total_revenue = (
+select
+max(total_revenue)
+from
+cte_revenue0 as t2
+)
+order by
+s_suppkey;
+s_suppkey	s_name	s_address	s_phone	total_revenue
+46	Supplier#000000046	e0URUXfDOYMdKe16Z5h5StMRbzGmTs,D2cjap	34-748-308-3215	128609.5280
+drop table t1;
+drop view simple_view;
+drop view complex_view;
+drop view complex_view_2;
+drop view complex_view_3;
+drop view revenue0;
+#
+# Test end
+#
+# Cleanup, drop testing tables ...
+START TRANSACTION;
+drop TABLE lineitem;
+drop TABLE orders;
+drop TABLE partsupp;
+drop TABLE part;
+drop TABLE customer;
+drop TABLE supplier;
+drop TABLE nation;
+drop TABLE region;
+COMMIT;
+set @@txsql_convert_view_to_cte_enabled = @saved_value;

--- a/mysql-test/t/view_to_cte.test
+++ b/mysql-test/t/view_to_cte.test
@@ -1,0 +1,241 @@
+set @saved_value = @@txsql_convert_view_to_cte_enabled;
+create table t1 (a int, b int);
+insert into t1 values (1,2), (1,3), (2,4), (2,5), (3,10);
+create view simple_view as
+select * from t1;
+
+create view complex_view as
+select b from t1 group by b;
+
+create view complex_view_2 as
+select b+1 from t1 group by b+1;
+
+create view complex_view_3 as
+select b from t1 group by b;
+
+###
+### different view with the same definition
+###
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from complex_view as d_1, complex_view_3 as d_2;
+select * from complex_view as d_1, complex_view_3 as d_2;
+
+###
+### different view with the different definition
+###
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from complex_view as d_1, complex_view_2 as d_2;
+select * from complex_view as d_1, complex_view_2 as d_2;
+
+###
+### view with RAND Note: MySQL allow CTE with rand so the same as txsql cte!
+###
+create view uncacheable_view as
+select b,rand() from t1 group by b;
+
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from uncacheable_view as d_1, uncacheable_view as d_2;
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from uncacheable_view as d_1, uncacheable_view as d_2;
+
+drop view uncacheable_view;
+
+###
+### a view referenced only once
+###
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from simple_view;
+select * from simple_view;
+
+explain format=tree select * from complex_view;
+select * from complex_view;
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from simple_view;
+select * from simple_view;
+
+explain format=tree select * from complex_view;
+select * from complex_view;
+
+###
+### a view referenced twice
+###
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from simple_view as d_1, simple_view as d_2;
+select * from simple_view as d_1, simple_view as d_2;
+
+explain format=tree select * from complex_view as d_1, complex_view as d_2;
+select * from complex_view as d_1, complex_view as d_2;
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from simple_view as d_1, simple_view as d_2;
+select * from simple_view as d_1, simple_view as d_2;
+
+explain format=tree select * from complex_view as d_1, complex_view as d_2;
+select * from complex_view as d_1, complex_view as d_2;
+
+###
+### the same derived table 
+###
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree select * from (select * from t1) as d_1, (select * from t1) as d_2;
+select * from (select * from t1) as d_1, (select * from t1) as d_2;
+
+explain format=tree select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree select * from (select * from t1) as d_1, (select * from t1) as d_2;
+select * from (select * from t1) as d_1, (select * from t1) as d_2;
+
+explain format=tree select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+select * from (select b from t1 group by b) as d_1, (select b from t1 group by b) as d_2;
+
+###
+### mysql cte
+###
+set @@txsql_convert_view_to_cte_enabled = 0;
+explain format=tree
+with simple_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+
+with complex_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+
+explain format=tree
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+explain format=tree
+with simple_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+
+with complex_view as (select * from t1)
+select * from simple_view as d_1, simple_view as d_2;
+
+explain format=tree
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+
+with simple_view as (select b from t1 group by b)
+select * from simple_view as d_1, simple_view as d_2;
+
+--disable_query_log
+--source suite/standard_benchmarks/inc/tpch_create_tables.inc
+--echo # Load data ...
+--source suite/standard_benchmarks/inc/tpch_load.inc
+--echo # Create indexes ...
+--source suite/standard_benchmarks/inc/tpch_create_indexes.inc
+--echo # Analyze tables ...
+analyze table customer, lineitem, nation, orders, part, partsupp, region, supplier;
+--enable_query_log
+
+create view revenue0 (supplier_no, total_revenue) as
+	select
+		l_suppkey,
+		sum(l_extendedprice * (1 - l_discount))
+	from
+		lineitem
+	where
+		l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+	group by
+		l_suppkey;
+
+let $Q15=
+select
+	s_suppkey,
+	s_name,
+	s_address,
+	s_phone,
+	total_revenue
+from
+	supplier,
+	revenue0
+where
+	s_suppkey = supplier_no
+	and total_revenue = (
+		select
+			max(total_revenue)
+		from
+			revenue0
+	)
+order by
+	s_suppkey;
+
+set @@txsql_convert_view_to_cte_enabled = 0;
+--replace_regex /cost=[0-9]+\.[0-9]+/cost=#/
+eval explain format=tree $Q15;
+--replace_regex /time=.+/time=X...)/
+eval explain analyze $Q15;
+eval $Q15;
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+--replace_regex /cost=[0-9]+\.[0-9]+/cost=#/
+eval explain format=tree $Q15;
+--replace_regex /time=.+/time=X...)/
+eval explain analyze $Q15;
+eval $Q15;
+
+let $Q15_new = with cte_revenue0 (supplier_no, total_revenue) as (
+	select
+		l_suppkey,
+		sum(l_extendedprice * (1 - l_discount))
+	from
+		lineitem
+	where
+		l_shipdate >= '1995-06-01'
+		and l_shipdate < date_add('1995-06-01', interval '90' day)
+	group by
+		l_suppkey)
+select
+	s_suppkey,
+	s_name,
+	s_address,
+	s_phone,
+	total_revenue
+from
+	supplier,
+	cte_revenue0 as t1
+where
+	s_suppkey = supplier_no
+	and total_revenue = (
+		select
+			max(total_revenue)
+		from
+			cte_revenue0 as t2
+	)
+order by
+	s_suppkey;
+
+set @@txsql_convert_view_to_cte_enabled = 0;
+--replace_regex /cost=[0-9]+\.[0-9]+/cost=#/
+eval explain format=tree $Q15_new;
+--replace_regex /time=.+/time=X...)/
+eval explain analyze $Q15_new;
+eval $Q15_new;
+
+set @@txsql_convert_view_to_cte_enabled = 1;
+--replace_regex /cost=[0-9]+\.[0-9]+/cost=#/
+eval explain format=tree $Q15_new;
+--replace_regex /time=.+/time=X...)/
+eval explain analyze $Q15_new;
+eval $Q15_new;
+
+drop table t1;
+drop view simple_view;
+drop view complex_view;
+drop view complex_view_2;
+drop view complex_view_3;
+drop view revenue0;
+--echo #
+--echo # Test end
+--echo #
+--echo # Cleanup, drop testing tables ...
+--source suite/standard_benchmarks/inc/tpch_drop.inc
+set @@txsql_convert_view_to_cte_enabled = @saved_value;

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -373,6 +373,8 @@ SET(SQL_PX_SOURCES
 ENDIF()
 
 SET(SQL_SHARED_SOURCES
+  txsql_cte/txsql_cte.cc
+  txsql_hash/txsql_hash.cc
   auth/auth_acls.cc
   auth/auth_common.cc
   auth/dynamic_privileges_impl.cc

--- a/sql/iterators/composite_iterators.cc
+++ b/sql/iterators/composite_iterators.cc
@@ -972,6 +972,17 @@ bool MaterializeIterator<Profiler>::Init() {
     }
   }
 
+  if (!table()->materialized && table()->pos_in_table_list &&
+      table()->pos_in_table_list->txsql_cte() != nullptr &&
+      table()->pos_in_table_list->txsql_cte()->tmp_tables.size() >= 2) {
+    for (TABLE_LIST *table_ref : table()->pos_in_table_list->txsql_cte()->tmp_tables) {
+      if (table_ref->table != nullptr && table_ref->table->materialized) {
+        table()->materialized = true;
+        break;
+      }
+    }
+  }
+
   if (table()->materialized) {
     bool rematerialize = m_rematerialize;
 

--- a/sql/join_optimizer/access_path.h
+++ b/sql/join_optimizer/access_path.h
@@ -1708,7 +1708,7 @@ inline AccessPath *NewMaterializeAccessPath(
     Mem_root_array<const AccessPath *> *invalidators, TABLE *table,
     AccessPath *table_path, Common_table_expr *cte, Query_expression *unit,
     int ref_slice, bool rematerialize, ha_rows limit_rows,
-    bool reject_multiple_rows) {
+    bool reject_multiple_rows, txsql::CTE_view_expr *cte_expr = nullptr) {
   MaterializePathParameters *param =
       new (thd->mem_root) MaterializePathParameters;
   param->query_blocks = std::move(query_blocks);
@@ -1726,6 +1726,9 @@ inline AccessPath *NewMaterializeAccessPath(
   param->rematerialize = rematerialize;
   param->limit_rows = limit_rows;
   param->reject_multiple_rows = reject_multiple_rows;
+  if (cte_expr && cte_expr->tmp_tables.size() >= 2) {
+    param->cte_expr = cte_expr;
+  }
 
 #ifndef NDEBUG
   for (MaterializePathParameters::QueryBlock &query_block :

--- a/sql/join_optimizer/explain_access_path.cc
+++ b/sql/join_optimizer/explain_access_path.cc
@@ -269,21 +269,50 @@ static void ExplainMaterializeAccessPath(const AccessPath *path, JOIN *join,
     }
   }();
 
+  const bool explain_txsql_cte_now = param->cte_expr != nullptr && [&]() {
+    if (explain_analyze) {
+      /*
+        Find the temporary table for which the CTE was materialized, if there
+        is one.
+      */
+      if (path->iterator == nullptr ||
+          path->iterator->GetProfiler()->GetNumInitCalls() == 0) {
+        // If the CTE was never materialized, print it at the first reference.
+        return param->table == param->cte_expr->tmp_tables[0]->table &&
+               std::none_of(param->cte_expr->tmp_tables.cbegin(),
+                            param->cte_expr->tmp_tables.cend(),
+                            [](const TABLE_LIST *tab) {
+                              return tab->table->materialized;
+                            });
+      } else {
+        // The CTE was materialized here, print it now with cost data.
+        return true;
+      }
+    } else {
+      // If we do not want cost data, print the plan at the first reference.
+      return param->table == param->cte_expr->tmp_tables[0]->table;
+    }
+  }();
+
   const bool is_union = param->query_blocks.size() > 1;
   string str;
 
-  if (param->cte != nullptr) {
-    if (param->cte->recursive) {
+  if (param->cte != nullptr || param->cte_expr != nullptr) {
+    assert(!(param->cte && param->cte_expr));
+    if (param->cte && param->cte->recursive) {
+      assert(!param->cte_expr);
       str = "Materialize recursive CTE " + to_string(param->cte->name);
     } else {
+      std::string cte_name = param->cte ? to_string(param->cte->name) : std::string("txsql cte");
       if (is_union) {
-        str = "Materialize union CTE " + to_string(param->cte->name);
+        str = "Materialize union CTE " + cte_name;
       } else {
-        str = "Materialize CTE " + to_string(param->cte->name);
+        str = "Materialize CTE " + cte_name;
       }
-      if (param->cte->tmp_tables.size() > 1) {
+      if ((param->cte && param->cte->tmp_tables.size() > 1) ||
+          (param->cte_expr && param->cte_expr->tmp_tables.size() > 1)) {
         str += " if needed";
-        if (!explain_cte_now) {
+        if ((param->cte && !explain_cte_now) || (param->cte_expr && !explain_txsql_cte_now)) {
           // See children().
           str += " (query plan printed elsewhere)";
         }
@@ -325,6 +354,10 @@ static void ExplainMaterializeAccessPath(const AccessPath *path, JOIN *join,
   // TODO(sgunders): Consider printing CTE query plans on the top level of the
   // query block instead?
   if (param->cte != nullptr && !explain_cte_now) {
+    return;
+  }
+
+  if (param->cte_expr != nullptr && !explain_txsql_cte_now) {
     return;
   }
 

--- a/sql/join_optimizer/join_optimizer.cc
+++ b/sql/join_optimizer/join_optimizer.cc
@@ -2187,7 +2187,7 @@ bool CostingReceiver::ProposeTableScan(
     } else {
       bool rematerialize = Overlaps(tl->derived_query_expression()->uncacheable,
                                     UNCACHEABLE_DEPENDENT);
-      if (tl->common_table_expr()) {
+      if (tl->common_table_expr() || (tl->txsql_cte() && tl->txsql_cte()->tmp_tables.size() >= 2)) {
         // Handled in clear_corr_derived_tmp_tables(), not here.
         rematerialize = false;
       }

--- a/sql/join_optimizer/materialize_path_parameters.h
+++ b/sql/join_optimizer/materialize_path_parameters.h
@@ -90,6 +90,8 @@ struct MaterializePathParameters {
   */
   bool reject_multiple_rows;
 
+  txsql::CTE_view_expr *cte_expr{nullptr};
+
 #if defined(HAVE_PX)
   /*
     The function only serves the plan equivalence comparison of parallel

--- a/sql/parallel_execution/px_access_path.cc
+++ b/sql/parallel_execution/px_access_path.cc
@@ -648,7 +648,7 @@ bool px_access_path::WalkAccessPathsForCompat(
       const auto &param = path->materialize();
 
       TABLE_LIST *tl = param.param->table->pos_in_table_list;
-      if ((tl && tl->is_view()) || param.param->cte ||
+      if ((tl && tl->is_view()) || param.param->cte || param.param->cte_expr ||
           (parallel_scan && param.param->table->materialized)) {
         // If the temporary table is already materialized, the subpath may not
         // be executed during execution.

--- a/sql/sql_class.cc
+++ b/sql/sql_class.cc
@@ -1956,6 +1956,9 @@ void THD::cleanup_after_query() {
   px_worker_executing = false;
 #endif
 #endif /* defined(HAVE_PX) */
+  if (!in_sub_stmt && !cte_map.empty()) {
+    txsql::cte_clear(&cte_map);
+  }
 }
 
 /*

--- a/sql/sql_class.h
+++ b/sql/sql_class.h
@@ -119,6 +119,7 @@
 
 /* Changes from TXSQL start. */
 #include "sql/sql_seq.h"
+#include "sql/txsql_cte/txsql_cte.h"
 #include <list>
 /* Changes from TXSQL end. */
 
@@ -1219,6 +1220,7 @@ class THD : public MDL_context_owner,
 #endif
 #endif /* defined(HAVE_PX) */
 
+  txsql::cte_map_t<txsql::CTE_view_expr> cte_map;
  private:
   /**
     The lex to hold the parsed tree of conventional (non-prepared) queries.

--- a/sql/sql_derived.cc
+++ b/sql/sql_derived.cc
@@ -777,6 +777,12 @@ bool TABLE_LIST::setup_materialized_derived_tmp_table(THD *thd)
   // From resolver POV, columns of this table are readonly
   set_readonly();
 
+  if (txsql_cte() && txsql_cte()->is_cte_consumer(this)) {
+    table = txsql_cte()->clone_tmp_table(thd, this);
+    if (table == nullptr) return true; /* purecov: inspected */
+    derived_result->table = table;
+  }
+
   if (m_common_table_expr && m_common_table_expr->tmp_tables.size() > 0) {
     trace_derived.add("reusing_tmp_table", true);
     table = m_common_table_expr->clone_tmp_table(thd, this);
@@ -971,7 +977,8 @@ bool TABLE_LIST::can_push_condition_to_derived(THD *thd) {
          !(common_table_expr() &&
            (common_table_expr()->references.size() >= 2 ||
             common_table_expr()->recursive)) &&   // 4
-         (thd->lex->set_var_list.elements == 0);  // 5
+         (thd->lex->set_var_list.elements == 0) &&  // 5
+         !(txsql_cte() && txsql_cte()->tmp_tables.size() >= 2);
 }
 
 /**

--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -1655,7 +1655,7 @@ AccessPath *GetAccessPathForDerivedTable(
         /*ref_slice=*/-1, rematerialize, query_expression->select_limit_cnt,
         query_expression->offset_limit_cnt == 0
             ? query_expression->m_reject_multiple_rows
-            : false);
+            : false, /*cte_expr=*/table_ref->txsql_cte());
     EstimateMaterializeCost(thd, path);
     path = MoveCompositeIteratorsFromTablePath(path);
     if (query_expression->offset_limit_cnt != 0) {
@@ -1698,7 +1698,8 @@ AccessPath *GetAccessPathForDerivedTable(
         invalidators, table, table_path, table_ref->common_table_expr(),
         query_expression,
         /*ref_slice=*/-1, rematerialize, tmp_table_param->end_write_records,
-        query_expression->m_reject_multiple_rows);
+        query_expression->m_reject_multiple_rows,
+        /*cte_expr=*/table_ref->txsql_cte());
     EstimateMaterializeCost(thd, path);
     path = MoveCompositeIteratorsFromTablePath(path);
   }

--- a/sql/sql_resolver.cc
+++ b/sql/sql_resolver.cc
@@ -112,6 +112,7 @@
 #include "sql/log.h"
 #include "template_utils.h"
 #include "thr_lock.h"  // TL_READ
+#include "sql/txsql_cte/txsql_cte.h"
 
 using std::function;
 
@@ -1281,6 +1282,19 @@ void Query_block::remap_tables(THD *thd) {
   }
 }
 
+static bool check_convert_view_to_cte_enable(TABLE_LIST *tl, LEX *lex, Query_block *block) {
+  if (!tl->is_view() ||
+      lex->sql_command != SQLCOM_SELECT ||
+      lex->is_from_ps ||
+      lex->is_executing_ps ||
+      lex->is_from_sp ||
+      block->uncacheable & UNCACHEABLE_RAND) {
+    return false;
+  }
+
+  return true;
+}
+
 /**
   @brief Resolve derived table, view or table function references in query block
 
@@ -1319,6 +1333,27 @@ bool Query_block::resolve_placeholder_tables(THD *thd, bool apply_semijoin) {
         return true; /* purecov: inspected */
     }
     if (tl->is_merged()) continue;
+
+    // Check if view is referenced multiple times
+    if (unlikely(thd->variables.txsql_convert_view_to_cte_enabled) &&
+        !thd->in_sub_stmt &&
+        check_convert_view_to_cte_enable(tl, thd->lex, this)) {
+      txsql::CTE_node *node = new (thd->mem_root) txsql::CTE_view(tl);
+      if (node == nullptr) return true;
+      auto cte_expr = thd->cte_map.find(node);
+      if (cte_expr == thd->cte_map.end()) {
+        txsql::CTE_view_expr *cte_view_expr = new (thd->mem_root) txsql::CTE_view_expr(thd->mem_root);
+        if (cte_view_expr == nullptr) return true;
+        thd->cte_map[node] = cte_view_expr;
+        cte_view_expr->tmp_tables.push_back(tl);
+        tl->set_cte_expr(cte_view_expr);
+      } else {
+        cte_expr->second->count++;
+        cte_expr->second->tmp_tables.push_back(tl);
+        tl->set_cte_expr(cte_expr->second);
+      }
+    }
+
     // Prepare remaining derived tables for materialization
     if (tl->is_table_function()) {
       if (tl->setup_table_function(thd)) {

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -2434,6 +2434,11 @@ void free_tmp_table(TABLE *table) {
     table->pos_in_table_list->common_table_expr()->remove_table(
         table->pos_in_table_list);
   }
+  if (table->pos_in_table_list != nullptr &&
+      table->pos_in_table_list->txsql_cte() != nullptr) {
+    table->pos_in_table_list->txsql_cte()->remove_table(
+        table->pos_in_table_list);
+  }
   /*
     In create_tmp_table(), the share's memroot is allocated inside own_root
     and is then made a copy of own_root, so it is inside its memory blocks,
@@ -2572,7 +2577,8 @@ bool create_ondisk_from_heap(THD *thd, TABLE *wtable, int error,
 
   if (wtable_list) {
     Common_table_expr *cte = wtable_list->common_table_expr();
-    if (cte) {
+    if (cte || (wtable_list->txsql_cte() && wtable_list->txsql_cte()->tmp_tables.size() >= 2)) {
+      assert(!(cte && wtable_list->txsql_cte()));
       int i = 0, found = -1;
       TABLE *t;
       while ((t = ref_it.get_next())) {
@@ -2585,7 +2591,8 @@ bool create_ondisk_from_heap(THD *thd, TABLE *wtable, int error,
       assert(found >= 0);
       if (found > 0)
         // 'wtable' is at position 'found', move it to 0 to convert it first
-        std::swap(cte->tmp_tables[0], cte->tmp_tables[found]);
+        std::swap(cte ? cte->tmp_tables[0] : wtable_list->txsql_cte()->tmp_tables[0],
+                  cte ? cte->tmp_tables[found] : wtable_list->txsql_cte()->tmp_tables[found]);
       ref_it.rewind();
     }
   }

--- a/sql/sys_vars.cc
+++ b/sql/sys_vars.cc
@@ -8347,6 +8347,13 @@ static Sys_var_bool Sys_txsql_range_estimation_by_histogram(
 static Sys_var_deprecated_alias Sys_range_estimation_by_histogram(
     "range_estimation_by_histogram", Sys_txsql_range_estimation_by_histogram);
 
+static Sys_var_bool Sys_txsql_convert_view_to_cte_enabled(
+    "txsql_convert_view_to_cte_enabled",
+    "When enabled, allow convert view to cte ",
+    SESSION_VAR(txsql_convert_view_to_cte_enabled), CMD_LINE(OPT_ARG),
+    DEFAULT(false), NO_MUTEX_GUARD, NOT_IN_BINLOG,
+    ON_CHECK(NULL), ON_UPDATE(NULL));
+
 static Sys_var_bool Sys_txsql_load_data_local_strict_mode(
     "txsql_load_data_local_strict_mode",
     "Whether to emit errors (or warnings) in strict mode when executing LOAD "

--- a/sql/system_variables.h
+++ b/sql/system_variables.h
@@ -552,6 +552,8 @@ struct System_variables {
 #endif /* HAVE_PX */
   /// @sa Sys_txsql_pread_count_enabled
   bool txsql_pread_count_enabled;
+  /// @sa Sys_txsql_convert_view_to_cte_enabled
+  bool txsql_convert_view_to_cte_enabled;
 };
 
 /**

--- a/sql/table.h
+++ b/sql/table.h
@@ -61,6 +61,8 @@
 #include "sql/sql_sort.h"  // Sort_result
 #include "thr_lock.h"
 #include "typelib.h"
+#include "sql/txsql_hash/txsql_hash.h"
+#include "sql/txsql_cte/txsql_cte.h"
 
 class Field;
 
@@ -3580,6 +3582,7 @@ struct TABLE_LIST {
   */
   const Create_col_name_list *m_derived_column_names{nullptr};
 
+  txsql::CTE_view_expr *m_txsql_cte{nullptr};
  public:
   ST_SCHEMA_TABLE *schema_table{nullptr}; /* Information_schema table */
   Query_block *schema_query_block{nullptr};
@@ -3866,6 +3869,9 @@ struct TABLE_LIST {
     m_derived_column_names = d;
   }
 
+  void set_cte_expr(txsql::CTE_view_expr *cte) { m_txsql_cte = cte; }
+
+  txsql::CTE_view_expr *txsql_cte() const { return m_txsql_cte; }
  private:
   /*
     A group of members set and used only during JOIN::optimize().
@@ -4362,11 +4368,23 @@ class Derived_refs_iterator {
   explicit Derived_refs_iterator(TABLE_LIST *start_arg) : start(start_arg) {}
   TABLE *get_next() {
     const Common_table_expr *cte = start->common_table_expr();
+    txsql::CTE_view_expr *view_cte = start->txsql_cte();
     m_is_first = ref_idx == 0;
     // Derived tables and views have a single reference.
-    if (cte == nullptr) {
+    if (cte == nullptr && (view_cte == nullptr || view_cte->tmp_tables.size() == 1)) {
       return ref_idx++ == 0 ? start->table : nullptr;
     }
+
+    if (view_cte != nullptr && view_cte->tmp_tables.size() >= 2) {
+      assert(!cte);
+      while (ref_idx < view_cte->tmp_tables.size()) {
+        TABLE *table = view_cte->tmp_tables[ref_idx++]->table;
+        if (table != nullptr) return table;
+      }
+      return nullptr;
+    }
+
+    assert(cte);
     /*
       CTEs may have multiple references. Return the next one, but notice that
       some references may have been deleted.

--- a/sql/txsql_cte/txsql_cte.cc
+++ b/sql/txsql_cte/txsql_cte.cc
@@ -1,0 +1,97 @@
+#include "sql/table.h"
+#include "sql/sql_base.h"
+#include "txsql_cte.h"
+
+namespace txsql {
+
+bool CTE_node::Equals(const CTE_node *other) const {
+	if (!other) {
+		return false;
+	}
+	if (this->type != other->type) {
+		return false;
+	}
+	return true;
+}
+
+CTE_view::CTE_view(const TABLE_LIST *view) : CTE_node(CTE_Type::VIEW), m_view(view) {}
+
+txsql::hash_t CTE_view::Hash() const {
+  assert(m_view);
+  txsql::hash_t hash = txsql::Hash<uint32_t>((uint32_t)type);
+  hash = txsql::CombineHash(hash, txsql::Hash<size_t>(m_view->select_stmt.length));
+	hash = txsql::CombineHash(hash, txsql::Hash((const char *)m_view->select_stmt.str, m_view->select_stmt.length));
+	return hash;
+}
+
+bool CTE_view::Equals(const CTE_node *other) const {
+  if (!CTE_node::Equals(other)) {
+    return false;
+  }
+
+  if (m_view->select_stmt.length != ((CTE_view *)other)->m_view->select_stmt.length) {
+    return false;
+  }
+
+  if (memcmp(m_view->select_stmt.str,
+      ((CTE_view *)other)->m_view->select_stmt.str, m_view->select_stmt.length)) {
+    return false;
+  }
+
+  return true;
+}
+
+CTE_view_expr::CTE_view_expr(MEM_ROOT *mem_root) : count(1), tmp_tables(mem_root) {}
+
+bool CTE_view_expr::is_cte_consumer(TABLE_LIST *table) const {
+  assert(tmp_tables.size());
+  auto first = tmp_tables[0];
+  return (first == table) ? false : true;
+}
+
+void CTE_view_expr::remove_table(TABLE_LIST *tr) {
+  (void)tmp_tables.erase_value(tr);
+  tr->set_cte_expr(nullptr);
+  --count;
+}
+
+TABLE *CTE_view_expr::clone_tmp_table(THD *thd, TABLE_LIST *tl) {
+  assert(tl->txsql_cte() == this);
+  TABLE *first = tmp_tables[0]->table;
+  // Allocate clone on the memory root of the TABLE_SHARE.
+  TABLE *t = static_cast<TABLE *>(first->s->mem_root.Alloc(sizeof(TABLE)));
+  if (!t) return nullptr; /* purecov: inspected */
+  if (open_table_from_share(thd, first->s, tl->alias,
+                            /*
+                              Pass db_stat == 0 to delay opening of table in SE,
+                              as table is not instantiated in SE yet.
+                            */
+                            0,
+                            /* We need record[1] for this TABLE instance. */
+                            EXTRA_RECORD |
+                                /*
+                                  Use DELAYED_OPEN to have its own record[0]
+                                  (necessary because db_stat is 0).
+                                  Otherwise it would be shared with 'first'
+                                  and thus a write to tmp table would modify
+                                  the row just read by readers.
+                                */
+                                DELAYED_OPEN,
+                            0, t, false, nullptr))
+    return nullptr; /* purecov: inspected */
+  assert(t->s == first->s && t != first && t->file != first->file);
+  t->s->increment_ref_count();
+  t->s->tmp_handler_count++;
+
+  // In case this clone is used to fill the materialized table:
+  bitmap_set_all(t->write_set);
+  t->reginfo.lock_type = TL_WRITE;
+  t->copy_blobs = true;
+  tl->table = t;
+  t->pos_in_table_list = tl;
+  t->set_not_started();
+
+  return t;
+}
+
+}

--- a/sql/txsql_cte/txsql_cte.h
+++ b/sql/txsql_cte/txsql_cte.h
@@ -1,0 +1,113 @@
+
+#ifndef TXSQL_CTE_H
+#define TXSQL_CTE_H
+
+#include <iostream>
+#include <unordered_map>
+#include "sql/mem_root_array.h"
+#include "include/my_alloc.h"
+#include "sql/txsql_hash/txsql_hash.h"
+
+class THD;
+struct TABLE_LIST;
+struct TABLE;
+
+namespace txsql {
+
+enum class CTE_Type : uint8_t {
+  INVALID = 0,
+  VIEW
+};
+
+/**
+  This structure represents an encapsulation of a structural object - such as a subplan,
+  view object, etc. After a structure is encapsulated as CTE_node, it is used as the
+  basic unit to detect whether it is repeated.
+  Note: Any CTE_node needs to have the Equals interface and the hash interface to achieve
+  duplicate detection.
+*/
+class CTE_node {
+ public:
+    CTE_node(CTE_Type type) : type(type) {}
+    virtual ~CTE_node() {}
+	  CTE_Type GetCteType() const { return type; }
+    CTE_Type type{CTE_Type::INVALID};
+ public:
+  virtual bool IsView() const = 0;
+  /**
+    Creates a hash value of this CTE_node.
+
+    It is important that if two CTE_node are identical
+    (i.e. CTE_node::Equals() returns true), that their
+    hash value is identical as well.
+  */
+  virtual txsql::hash_t Hash() const = 0;
+  virtual bool Equals(const CTE_node *other) const;
+  static bool Equals(const CTE_node *left, const CTE_node *right) {
+		if (left == right) { return true;}
+		if (!left || !right) { return false; }
+		return left->Equals(right);
+	}
+	bool operator==(const CTE_node &rhs) { return this->Equals(&rhs); }
+};
+
+class CTE_view : public CTE_node {
+  public:
+    CTE_view(const TABLE_LIST *view);
+    ~CTE_view() {}
+
+  public:
+    virtual bool IsView() const override { return true; }
+    virtual txsql::hash_t Hash() const override;
+    virtual bool Equals(const CTE_node *other) const override;
+    const TABLE_LIST *getView() { return m_view; }
+  private:
+    // The target table of the current node 
+    const TABLE_LIST *m_view{nullptr};
+};
+
+/**
+  The CTE_view_expr structure represents a set of CTEs converted from subplan.
+  Each repeated CTE_view will correspond to a TABLE_LIST (representing target
+  table). A set of repeated subplans is maintained using tmp_tables, where
+  tmp_tables[0] represents the producer - which will perform complete
+  evaluation and materialization, and tmp_tables subsequently represents the
+  consumer, which reads the results directly from the materialized TABLE.
+*/
+struct CTE_view_expr {
+  CTE_view_expr(MEM_ROOT *mem_root);
+  bool is_cte_consumer(TABLE_LIST *table) const;
+  TABLE *clone_tmp_table(THD *thd, TABLE_LIST *tl);
+  void remove_table(TABLE_LIST *tr);
+
+  uint count;
+  Mem_root_array<TABLE_LIST *> tmp_tables;
+};
+
+struct CteHashFunction {
+	uint64_t operator()(const CTE_node *const &node) const {
+		return (uint64_t)node->Hash();
+	}
+};
+
+struct CteEqualFunction {
+	bool operator()(const CTE_node *const &a, const CTE_node *const &b) const {
+		return a->Equals(b);
+	}
+};
+
+template <typename T>
+using cte_map_t = std::unordered_map<CTE_node *, T *, CteHashFunction, CteEqualFunction>;
+
+template <typename T>
+void cte_clear(cte_map_t<T> *m) {
+  for (auto it = m->begin(); it != m->end(); ++it) {
+    destroy(it->first);
+    destroy(it->second);
+  }
+  m->clear();
+}
+
+}
+
+#endif

--- a/sql/txsql_hash/txsql_hash.cc
+++ b/sql/txsql_hash/txsql_hash.cc
@@ -1,0 +1,132 @@
+#include <functional>
+#include <cmath>
+#include <string.h>
+#include "txsql_hash.h"
+#include "include/m_ctype.h"
+
+namespace txsql {
+template <>
+hash_t Hash(uint64_t val) {
+	return murmurhash64(val);
+}
+
+template <>
+hash_t Hash(int64_t val) {
+	return murmurhash64((uint64_t)val);
+}
+
+template <class T>
+struct FloatingPointEqualityTransform {
+	static void OP(T &val) {
+		if (val == (T)0.0) {
+			// Turn negative zero into positive zero
+			val = (T)0.0;
+		} else if (std::isnan(val)) {
+			val = std::numeric_limits<T>::quiet_NaN();
+		}
+	}
+};
+
+template <>
+hash_t Hash(float val) {
+	static_assert(sizeof(float) == sizeof(uint32_t), "");
+	FloatingPointEqualityTransform<float>::OP(val);
+	uint32_t uval = Load<uint32_t>((const_data_ptr_t)&val);
+	return murmurhash64(uval);
+}
+
+template <>
+hash_t Hash(double val) {
+	static_assert(sizeof(double) == sizeof(uint64_t), "");
+	FloatingPointEqualityTransform<double>::OP(val);
+	uint64_t uval = Load<uint64_t>((const_data_ptr_t)&val);
+	return murmurhash64(uval);
+}
+
+template <>
+hash_t Hash(interval_t val) {
+	return Hash(val.days) ^ Hash(val.months) ^ Hash(val.micros);
+}
+
+template <>
+hash_t Hash(const char *str) {
+	return Hash(str, strlen(str));
+}
+
+template <>
+hash_t Hash(char *val) {
+	return Hash<const char *>(val);
+}
+
+// MIT License
+// Copyright (c) 2018-2021 Martin Ankerl
+// https://github.com/martinus/robin-hood-hashing/blob/3.11.5/LICENSE
+hash_t HashBytes(void *ptr, size_t len) noexcept {
+	static constexpr uint64_t M = UINT64_C(0xc6a4a7935bd1e995);
+	static constexpr uint64_t SEED = UINT64_C(0xe17a1465);
+	static constexpr unsigned int R = 47;
+
+	auto const *const data64 = static_cast<uint64_t const *>(ptr);
+	uint64_t h = SEED ^ (len * M);
+
+	size_t const n_blocks = len / 8;
+	for (size_t i = 0; i < n_blocks; ++i) {
+		auto k = Load<uint64_t>(reinterpret_cast<const_data_ptr_t>(data64 + i));
+
+		k *= M;
+		k ^= k >> R;
+		k *= M;
+
+		h ^= k;
+		h *= M;
+	}
+
+	auto const *const data8 = reinterpret_cast<uint8_t const *>(data64 + n_blocks);
+	switch (len & 7U) {
+	case 7:
+		h ^= static_cast<uint64_t>(data8[6]) << 48U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 6:
+		h ^= static_cast<uint64_t>(data8[5]) << 40U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 5:
+		h ^= static_cast<uint64_t>(data8[4]) << 32U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 4:
+		h ^= static_cast<uint64_t>(data8[3]) << 24U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 3:
+		h ^= static_cast<uint64_t>(data8[2]) << 16U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 2:
+		h ^= static_cast<uint64_t>(data8[1]) << 8U;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	case 1:
+		h ^= static_cast<uint64_t>(data8[0]);
+		h *= M;
+		DUCKDB_EXPLICIT_FALLTHROUGH;
+	default:
+		break;
+	}
+	h ^= h >> R;
+	h *= M;
+	h ^= h >> R;
+	return static_cast<hash_t>(h);
+}
+
+hash_t Hash(const char *val, size_t size) {
+	return HashBytes((void *)val, size);
+}
+
+hash_t Hash(uint8_t *val, size_t size) {
+	return HashBytes((void *)val, size);
+}
+
+hash_t my_strcasehash(const CHARSET_INFO *cs, const char *val, size_t size) {
+	assert(cs);
+	uint64_t n1, n2;
+	cs->coll->hash_sort(cs, (const uchar *)val, size, &n1, &n2);
+	return n1;
+}
+
+}

--- a/sql/txsql_hash/txsql_hash.h
+++ b/sql/txsql_hash/txsql_hash.h
@@ -1,0 +1,105 @@
+#ifndef TXSQL_HASH_H
+#define TXSQL_HASH_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+struct CHARSET_INFO;
+/**
+  The implementation of the basic hash function refers to DuckDB. See
+  common/types/hash.cpp in DuckDB for more informations. The latest
+  relevant commit is: 1c653367c4067fd271116d062d6fffc3df2fbbde.
+*/
+namespace txsql {
+// explicit fallthrough for switch_statementss
+#ifndef __has_cpp_attribute // For backwards compatibility
+#define __has_cpp_attribute(x) 0
+#endif
+#if __has_cpp_attribute(clang::fallthrough)
+#define DUCKDB_EXPLICIT_FALLTHROUGH [[clang::fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+#define DUCKDB_EXPLICIT_FALLTHROUGH [[gnu::fallthrough]]
+#else
+#define DUCKDB_EXPLICIT_FALLTHROUGH
+#endif
+
+//! The type used for hashes
+typedef uint64_t hash_t;
+
+//! data pointers
+typedef uint8_t data_t;
+typedef data_t *data_ptr_t;
+typedef const data_t *const_data_ptr_t;
+
+template <typename T>
+const T Load(const_data_ptr_t ptr) {
+	T ret;
+	memcpy(&ret, ptr, sizeof(ret));
+	return ret;
+}
+
+template <typename T>
+void Store(const T val, data_ptr_t ptr) {
+	memcpy(ptr, (void *)&val, sizeof(val));
+}
+
+struct interval_t {
+	int32_t months;
+	int32_t days;
+	int64_t micros;
+
+	inline bool operator==(const interval_t &rhs) const {
+		return this->days == rhs.days && this->months == rhs.months && this->micros == rhs.micros;
+	}
+};
+
+/*
+  efficient hash function that maximizes the avalanche effect and minimizes bias
+  see: https://nullprogram.com/blog/2018/07/31/
+*/
+
+inline hash_t murmurhash64(uint64_t x) {
+	x ^= x >> 32;
+	x *= 0xd6e8feb86659fd93U;
+	x ^= x >> 32;
+	x *= 0xd6e8feb86659fd93U;
+	x ^= x >> 32;
+	return x;
+}
+
+inline hash_t murmurhash32(uint32_t x) {
+	return murmurhash64(x);
+}
+
+template <class T>
+hash_t Hash(T value) {
+	return murmurhash32(value);
+}
+
+//! Combine two hashes by XORing them
+inline hash_t CombineHash(hash_t left, hash_t right) {
+	return left ^ right;
+}
+
+template <>
+hash_t Hash(uint64_t val);
+template <>
+hash_t Hash(int64_t val);
+template <>
+hash_t Hash(float val);
+template <>
+hash_t Hash(double val);
+template <>
+hash_t Hash(const char *val);
+template <>
+hash_t Hash(char *val);
+template <>
+hash_t Hash(interval_t val);
+hash_t Hash(const char *val, size_t size);
+hash_t Hash(uint8_t *val, size_t size);
+
+hash_t my_strcasehash(const CHARSET_INFO *cs, const char *val, size_t size);
+}
+
+#endif


### PR DESCRIPTION
…mes to CTE

Problem:
=======
CTE (common table expression) is an important expression to eliminate repeated evaluation of a view that is referenced multiple times. Views, unlike CTEs, need to be evaluated once every time they are referenced. If the same view that cannot be merged is referenced multiple times by a single SQL, there is a cost of repeated evaluation.

Solution:
=======
For views that cannot be merged and are referenced multiple times, they will be implicitly converted to CTEs in the prepare phase. In order to count the number of times a view appears, it is necessary to implement the equal interface and the hash interface for the view object. In the current implementation, the equal and hash of views are implemented based on the view definition statement, and the equal and hash judgments of operators and expressions are not introduced.

A variable txsql_convert_view_to_cte_enabled is introduced as a switch, which is turned to off by default. It should be noted that there are some differences in behavior between views and CTEs:
1) Where conditions are not allowed to push-down to CTE, but are allowed to
   push-down to the view
2) The rand function is allowed in the CTE, even if the CTE is referenced
   multiple times
Therefore, the implicit conversion of views to CTEs leads to some difference in optimization and results, it is up to the user to use that optimization or not.