### PR TITLE
BUG#34930969: Previous_gtids miss gtid when binlog_order_commits off

### DIFF
--- a/mysql-test/suite/rpl/r/rpl_previous_gtids.result
+++ b/mysql-test/suite/rpl/r/rpl_previous_gtids.result
@@ -1,0 +1,48 @@
+#
+# Use default connection to master.
+#
+RESET MASTER;
+SET @old_binlog_order_commits = @@global.binlog_order_commits;
+SET GLOBAL binlog_order_commits = 0;
+#
+# Create table. Use GTID 1
+#
+CREATE TABLE t1 (id INT PRIMARY KEY);
+#
+# Make another connection. Set to stop at after dec_prep_xids.
+#
+SET DEBUG_SYNC = "after_dec_prep_xids SIGNAL signal.after_dec_prep_xids_reached WAIT_FOR signal.after_dec_prep_xids_unblock";
+#
+# Use GTID 2. Stop after dec_prep_xids. If commit is executed before
+# dec_prep_xids then GTID 2 will be used out.
+#
+INSERT INTO t1 VALUES(1);
+#
+# Use default connection to master.
+#
+#
+# Wait until after_dec_prep_xids is reached
+#
+SET DEBUG_SYNC = "now WAIT_FOR signal.after_dec_prep_xids_reached";
+#
+# Use GTID 3. Force to rotate to log 'master-bin.000001'
+# All GTID 1-3 should be used in 'master-bin.000001'
+#
+SET SESSION debug = "+d,force_rotate";
+INSERT INTO t1 VALUES(2);
+SET SESSION debug = "-d,force_rotate";
+#
+# Add transaction in new binary log 'master-bin.000002'
+# GTID 4 should be used.
+#
+SET DEBUG_SYNC = 'now SIGNAL signal.after_dec_prep_xids_unblock';
+INSERT INTO t1 VALUES(3);
+#
+# Check all GTID 1-3 are used by looking at 'master-bin.000002'
+#
+include/assert.inc [Previous_gtids should use UUID:1-3 GTID]
+#
+# Cleanup
+#
+DROP TABLE t1;
+SET GLOBAL binlog_order_commits = @old_binlog_order_commits;

--- a/mysql-test/suite/rpl/t/rpl_previous_gtids-master.opt
+++ b/mysql-test/suite/rpl/t/rpl_previous_gtids-master.opt
@@ -1,0 +1,1 @@
+--log-bin=master-bin --gtid_mode=on --enforce_gtid_consistency=on

--- a/mysql-test/suite/rpl/t/rpl_previous_gtids.test
+++ b/mysql-test/suite/rpl/t/rpl_previous_gtids.test
@@ -1,0 +1,104 @@
+# === Purpose ===
+#
+# When binlog_order_commits is off then binlog rotate will wait for 'm_prep_xids' decrease to zero.
+# However 'm_prep_xids' is decreased before update thd's GTID to 'executed_gtids' so GTID may be missed
+# in the next binlog file's Previous_gtids event (see function MYSQL_BIN_LOG::finish_commit)
+#
+# ==== Requirements ====
+#
+# R1. Client transactions are guaranteed to have monotonically increasing GTIDs
+# without gaps between the generated numbers.
+#
+# === Implementation ====
+#
+# Ensure GTID XID is decreased after commit
+# 1. Create table t1. GTID 1
+# 2. Insert into t1. GTID 2 in a new connection. Stop after commit and decrease XID.
+# 3. Insert into t1. GTID 3. Rotate log file. XID 1-3 should be used in 'master-bin.000002'.
+# 4. Check GTID are used out by looking at log file 'master-bin.000002'.
+#
+# === References ===
+#
+# BUG #34930969	Contribution by Tencent: Previous_gtids miss gtid when binlog_order_commits off
+#
+--source include/have_debug.inc
+--source include/have_innodb.inc
+--source include/have_debug.inc
+--source include/have_gtid.inc
+--source include/have_log_bin.inc
+
+--echo #
+--echo # Use default connection to master.
+--echo #
+
+--connection default
+
+RESET MASTER;
+
+SET @old_binlog_order_commits = @@global.binlog_order_commits;
+SET GLOBAL binlog_order_commits = 0;
+
+--echo #
+--echo # Create table. Use GTID 1
+--echo #
+
+CREATE TABLE t1 (id INT PRIMARY KEY);
+
+--echo #
+--echo # Make another connection. Set to stop at after dec_prep_xids.
+--echo #
+
+--connect(con1,localhost,root,,)
+SET DEBUG_SYNC = "after_dec_prep_xids SIGNAL signal.after_dec_prep_xids_reached WAIT_FOR signal.after_dec_prep_xids_unblock";
+
+--echo #
+--echo # Use GTID 2. Stop after dec_prep_xids. If commit is executed before
+--echo # dec_prep_xids then GTID 2 will be used out.
+--echo #
+
+--send
+INSERT INTO t1 VALUES(1);
+
+--echo #
+--echo # Use default connection to master.
+--echo #
+
+--connection default
+
+--echo #
+--echo # Wait until after_dec_prep_xids is reached
+--echo #
+
+SET DEBUG_SYNC = "now WAIT_FOR signal.after_dec_prep_xids_reached";
+
+--echo #
+--echo # Use GTID 3. Force to rotate to log 'master-bin.000002'
+--echo # All GTID 1-3 should be used in 'master-bin.000001'
+--echo #
+
+SET SESSION debug = "+d,force_rotate";
+INSERT INTO t1 VALUES(2);
+SET SESSION debug = "-d,force_rotate";
+
+--echo #
+--echo # Add transaction in new binary log 'master-bin.000002'
+--echo # GTID 4 should be used.
+--echo #
+
+SET DEBUG_SYNC = 'now SIGNAL signal.after_dec_prep_xids_unblock';
+INSERT INTO t1 VALUES(3);
+
+--echo #
+--echo # Check all GTID 1-3 are used by looking at 'master-bin.000002'
+--echo #
+
+--let $assert_cond = \'[\'SHOW BINLOG EVENTS IN "master-bin.000002" LIMIT 1, 1\', Info, 1]\' LIKE \'%1-3\'
+--let $assert_text = Previous_gtids should use UUID:1-3 GTID
+--source include/assert.inc
+
+--echo #
+--echo # Cleanup
+--echo #
+
+DROP TABLE t1;
+SET GLOBAL binlog_order_commits = @old_binlog_order_commits;

--- a/sql/binlog.cc
+++ b/sql/binlog.cc
@@ -9224,6 +9224,8 @@ int MYSQL_BIN_LOG::finish_commit(THD *thd) {
     dec_prep_xids(thd);
   }
 
+  DEBUG_SYNC(thd, "after_dec_prep_xids");
+
   // If the transaction was committed successfully, run the after_commit
   if (committed_low && (thd->commit_error != THD::CE_COMMIT_ERROR) &&
       thd->get_transaction()->m_flags.run_hooks) {


### PR DESCRIPTION
When binlog_order_commits is off, binlog rotate will wait for 'm_prep_xids' to decrease to zero. However, 'm_prep_xids' was decreased before updating the thread's GTID to 'gtid_executed' in MYSQL_BIN_LOG::finish_commit, causing GTIDs to be missed in the next binlog file's Previous_gtids event.

The core fix (dec_prep_xids after gtid_state->update_on_commit) is already present in TXSQL. This commit adds:

1. DEBUG_SYNC point 'after_dec_prep_xids' after dec_prep_xids in finish_commit, enabling the MTR test case to inject delays for verification.

2. MTR test case rpl_previous_gtids to verify that GTIDs 1-3 are correctly recorded in Previous_gtids event of the next binary log file when binlog_order_commits=0.

Contribution by Tencent.