### PR TITLE
Bug#39033858 Parallel_reader::Scan_ctx::copy_row copies wrong range of bytes

### DIFF
--- a/storage/innobase/row/row0pread.cc
+++ b/storage/innobase/row/row0pread.cc
@@ -489,9 +489,14 @@ void Parallel_reader::Scan_ctx::copy_row(const rec_t *rec, Iter *iter) const {
 
   auto copy_rec = static_cast<rec_t *>(mem_heap_alloc(iter->m_heap, rec_len));
 
-  memcpy(copy_rec, rec, rec_len);
+  /* In InnoDB rec_t points after the extra bytes. */
+  const auto extra = rec_offs_extra_size(iter->m_offsets);
+  ut_ad(extra <= rec_len);
 
-  iter->m_rec = copy_rec;
+  memcpy(copy_rec, rec - extra, rec_len);
+  /* Even though we (by convention) point after extra bytes, all of them
+  will be freed, as instead of free(iter->m_rec) we use mem_heap_empty(). */
+  iter->m_rec = copy_rec + extra;
 
   auto tuple = row_rec_to_index_entry_low(iter->m_rec, m_config.m_index,
                                           iter->m_offsets, iter->m_heap);


### PR DESCRIPTION
issue #95  Bug#39033858 Parallel_reader::Scan_ctx::copy_row copies wrong range of bytes

Problem:

InnoDB uses a convention where rec pointers point in between two fragments of the record: to the left of it, are so called "extra" bytes which contain metadata such as flags, info about which fields are null and what is their length. To the right of it, is the actual data of the fields.
The function rec_offs_size(offsets) returns the total length of the record which is the sum of these two:
```
rec_offs_data_size(offsets) + rec_offs_extra_size(offsets)
```
The logic of Parallel_reader::Scan_ctx::copy_row() copied that many bytes into a freshly allocated buffer, but used rec address as the source, instead of "rec - extra", resulting in copying wrong range of bytes.

Solution:

Adjust the logic to copy the correct range of bytes.

Change-Id: Ia0463e4a752dfce70ff5a2ac83818132de9a638c