### PR TITLE
Bug #34893684: Alter Table IMPORT TABLESPACE crashes after upgrade

### DIFF
--- a/storage/innobase/row/row0import.cc
+++ b/storage/innobase/row/row0import.cc
@@ -1685,6 +1685,14 @@ dberr_t row_import::match_instant_metadata_in_target_table(THD *thd) {
     /* Search for this column in target table */
     dict_col_t *target_col = m_table->get_col_by_name(col_name);
 
+    if (target_col == nullptr) {
+      ib_errf(thd, IB_LOG_LEVEL_ERROR, ER_TABLE_SCHEMA_MISMATCH,
+              "Instant metadata didn't match for dropped column");
+      return DB_ERROR;
+    }
+
+    ut_a(target_col != nullptr);
+
     if (!cfg_col->is_version_added_match(target_col) ||
         !cfg_col->is_version_dropped_match(target_col) ||
         (cfg_col->ind != target_col->ind) ||


### PR DESCRIPTION
PROBLEM:
- In current version pattern for naming hidden dropped column has changed.
- When cfg file is taken from older version hidden dropped column name follows old pattern.
- When INSTANT operations are done in current version exactly in same order as done before creating cfg file, then the server crashes.

FIX:
- When searching dropped column with older name version returns null, IMPORT fails with error SCHEMA_MISMATCH.

Port from mysql-server,
commit 4693e7807c21345e69f6808607c907a2f509319e