### PR TITLE
Bug#38328780: mysqld fails to start with assertions

### DIFF
--- a/mysql-test/r/windows_skip_grant_validation.result
+++ b/mysql-test/r/windows_skip_grant_validation.result
@@ -1,0 +1,3 @@
+# Stop DB server which was created by MTR default
+Pattern "TCP/IP, --shared-memory, or --named-pipe should be configured on NT OS" found
+# restart

--- a/mysql-test/t/windows_skip_grant_validation.test
+++ b/mysql-test/t/windows_skip_grant_validation.test
@@ -1,0 +1,29 @@
+#
+# Test checking whether server cleanly exits after being provided an invalid
+# combination of command line arguments in windows when --skip-grant-tables
+# is used without enabling networking.
+#
+
+--source include/have_debug.inc
+--source include/windows.inc
+
+--let $MYSQLD_LOG= $MYSQL_TMP_DIR/server.log
+--let $MYSQLD_DATADIR= `SELECT @@datadir`
+
+--echo # Stop DB server which was created by MTR default
+--source include/shutdown_mysqld.inc
+
+# Make sure server exits with the right status and message after being provided
+# incorrect startup options. In windows, when starting without checking user
+# privileges TCP/IP, --shared-memory, or --named-pipe should be enabled to
+# allow remote connections.
+--error 1
+--exec $MYSQLD_CMD --log-error=$MYSQLD_LOG --datadir=$MYSQLD_DATADIR --skip-grant-tables
+
+--let SEARCH_FILE=$MYSQLD_LOG
+--let SEARCH_PATTERN=TCP/IP, --shared-memory, or --named-pipe should be configured on NT OS
+--source include/search_pattern.inc
+
+--remove_file $MYSQLD_LOG
+
+--source include/start_mysqld.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -3569,6 +3569,7 @@ void setup_conn_event_handler_threads() {
 
   if ((!have_tcpip || opt_disable_networking) && !opt_enable_shared_memory &&
       !opt_enable_named_pipe) {
+    terminate_compress_gtid_table_thread();
     LogErr(ERROR_LEVEL, ER_WIN_LISTEN_BUT_HOW);
     unireg_abort(MYSQLD_ABORT_EXIT);  // Will not return
   }


### PR DESCRIPTION
    Background:
    -----------
    When server is started with --skip-grant-tables privileges are not
    checked. Remote connections are not allowed. In Windows, server has to
    be run with TCP/IP, --shared-memory, or --named-pipe should be enabled
    to allow remote connections. Otherwise server is not started and exits
    execution early with a message that it was started with wrong
    parameters.

    Problem:
    --------
    During early return server did not end the replication tracker thread
    and compress GTID thread before it started to shut down the plugins as
    it is done during normal server shutdown. As a result of that InnoDB
    shutdown failed because it detected open transactions from those
    threads.

    Fix:
    ----
    During early exit caused by missing TCP/IP configuration,
    --shared-memory, or --named-pipe parameters when using
    --skip-grant-tables server stops replication tracker worker thread and
    compress GTID thread, before shutting down plugins.

    Change-Id: Ice534a5726adbe8e09555312396f0a7a0a813017