### PR TITLE
Bug#37278449: Backport fix for bug #37161583 to MySQL Server 8.0/8.4

### DIFF
--- a/mysql-test/r/hash_join.result
+++ b/mysql-test/r/hash_join.result
@@ -4016,3 +4016,46 @@ EXPLAIN
 
 DROP TABLE t1,t2;
 DROP VIEW vmerge;
+#
+# Bug#37161583: Incorrect result with LEFT JOIN and small
+#               join_buffer_size
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES (NULL);
+CREATE TABLE t2(b INT);
+INSERT INTO t2
+WITH RECURSIVE
+s(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM s WHERE n < 1000)
+SELECT n FROM s;
+ANALYZE TABLE t1, t2;
+Table	Op	Msg_type	Msg_text
+test.t1	analyze	status	OK
+test.t2	analyze	status	OK
+EXPLAIN FORMAT=TREE SELECT * FROM t1 WHERE NOT EXISTS (SELECT * FROM t2 WHERE a = b);
+EXPLAIN
+-> Hash antijoin (t2.b = t1.a)  (cost=*** rows=1000)
+    -> Table scan on t1  (cost=*** rows=1)
+    -> Hash
+        -> Table scan on t2  (cost=*** rows=1000)
+
+Warnings:
+Note	1276	Field or reference 'test.t1.a' of SELECT #2 was resolved in SELECT #1
+TRUNCATE performance_schema.file_summary_by_event_name;
+SET join_buffer_size = DEFAULT;
+SELECT * FROM t1 WHERE NOT EXISTS (SELECT * FROM t2 WHERE a = b);
+a
+NULL
+SELECT COUNT_STAR > 0 FROM performance_schema.file_summary_by_event_name
+WHERE event_name LIKE '%hash_join%';
+COUNT_STAR > 0
+0
+TRUNCATE performance_schema.file_summary_by_event_name;
+SET join_buffer_size = 128;
+SELECT * FROM t1 WHERE NOT EXISTS (SELECT * FROM t2 WHERE a = b);
+a
+NULL
+SET join_buffer_size = DEFAULT;
+SELECT COUNT_STAR > 0 FROM performance_schema.file_summary_by_event_name
+WHERE event_name LIKE '%hash_join%';
+COUNT_STAR > 0
+1
+DROP TABLE t1, t2;

--- a/mysql-test/t/hash_join.test
+++ b/mysql-test/t/hash_join.test
@@ -2562,3 +2562,48 @@ EXPLAIN FORMAT=tree SELECT * FROM t1 LEFT JOIN vmerge AS v ON t1.f1 = v.f1;
 
 DROP TABLE t1,t2;
 DROP VIEW vmerge;
+
+--echo #
+--echo # Bug#37161583: Incorrect result with LEFT JOIN and small
+--echo #               join_buffer_size
+
+CREATE TABLE t1(a INT);
+INSERT INTO t1 VALUES (NULL);
+
+CREATE TABLE t2(b INT);
+INSERT INTO t2
+  WITH RECURSIVE
+    s(n) AS (SELECT 1 UNION ALL SELECT n + 1 FROM s WHERE n < 1000)
+  SELECT n FROM s;
+
+ANALYZE TABLE t1, t2;
+
+--let $query = SELECT * FROM t1 WHERE NOT EXISTS (SELECT * FROM t2 WHERE a = b)
+
+# We want to test a hash antijoin.
+--skip_if_hypergraph  # Different query plan (nested loop join).
+--replace_regex /cost=\d+.\d+/cost=***/
+--eval EXPLAIN FORMAT=TREE $query
+
+# First verify that we get the correct result with DEFAULT
+# join_buffer_size, when the operation does not spill to disk.
+TRUNCATE performance_schema.file_summary_by_event_name;
+SET join_buffer_size = DEFAULT;
+--sorted_result
+--eval $query
+# Verify that the operation did not spill to disk.
+--eval $hash_join_file_operations
+
+# Then verify that we get the correct result with a so small join
+# buffer that the operation spills to disk. It used to return zero
+# rows.
+TRUNCATE performance_schema.file_summary_by_event_name;
+SET join_buffer_size = 128;
+--sorted_result
+--eval $query
+SET join_buffer_size = DEFAULT;
+# Verify that the operation spilled to disk.
+--skip_if_hypergraph  # Does not use hash join, so does not spill to disk.
+--eval $hash_join_file_operations
+
+DROP TABLE t1, t2;

--- a/sql/iterators/hash_join_iterator.cc
+++ b/sql/iterators/hash_join_iterator.cc
@@ -915,18 +915,27 @@ bool HashJoinIterator::WriteProbeRowToDiskIfApplicable() {
   // need to write it out to disk. Outer joins should always write the row out
   // to disk, since the probe/left input should return NULL-complemented rows
   // even if the join condition contains SQL NULL.
-  const bool write_rows_with_null_in_join_key = m_join_type == JoinType::OUTER;
   if (m_state == State::READING_FIRST_ROW_FROM_HASH_TABLE) {
     const bool found_match = m_current_row != nullptr;
 
     if ((m_join_type == JoinType::INNER || m_join_type == JoinType::OUTER) ||
         !found_match) {
       if (on_disk_hash_join() && m_current_chunk == -1) {
+        // For inner joins and semijoins, we can skip probe rows that have a
+        // NULL in the join key, unless the join condition uses NULL-safe equal
+        // (<=>), because we know that it won't have any match in the build
+        // table. For left outer join and antijoin, however, rows in the
+        // outer/probe table which have no match in the inner/build table, will
+        // be part of the join result, so we can't skip rows with NULLs for
+        // those join types. Hence, store_row_with_null_in_join_key must be true
+        // for left outer join and antijoin.
+        const bool store_row_with_null_in_join_key =
+            m_join_type == JoinType::OUTER || m_join_type == JoinType::ANTI;
         if (WriteRowToChunk(thd(), &m_chunk_files_on_disk,
                             false /* write_to_build_chunk */,
                             m_probe_input_tables, m_join_conditions,
                             kChunkPartitioningHashSeed, found_match,
-                            write_rows_with_null_in_join_key,
+                            store_row_with_null_in_join_key,
                             &m_temporary_row_and_join_key_buffer)) {
           return true;
         }

--- a/unittest/gunit/fake_integer_iterator.h
+++ b/unittest/gunit/fake_integer_iterator.h
@@ -23,6 +23,7 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA  */
 
+#include <optional>
 #include <random>
 #include <string>
 #include <vector>
@@ -41,10 +42,17 @@
 class FakeIntegerIterator final : public TableRowIterator {
  public:
   FakeIntegerIterator(THD *thd, TABLE *table, Field_long *field,
-                      std::vector<int> dataset)
+                      std::vector<std::optional<int>> dataset)
       : TableRowIterator(thd, table),
         m_field(field),
-        m_dataset(move(dataset)) {}
+        m_dataset(std::move(dataset)) {}
+
+  FakeIntegerIterator(THD *thd, TABLE *table, Field_long *field,
+                      std::vector<int> dataset)
+      : TableRowIterator(thd, table), m_field(field) {
+    m_dataset.reserve(dataset.size());
+    for (int v : dataset) m_dataset.emplace_back(v);
+  }
 
   bool Init() override {
     m_current_index = 0;
@@ -57,7 +65,14 @@ class FakeIntegerIterator final : public TableRowIterator {
       return -1;
     }
 
-    m_field->store(m_dataset[m_current_index++], /* is_unsigned */ false);
+    const std::optional<int> value = m_dataset[m_current_index++];
+    if (value.has_value()) {
+      m_field->store(*value, /*unsigned_val=*/false);
+      m_field->set_notnull();
+    } else {
+      m_field->set_null();
+    }
+
     return 0;
   }
 
@@ -67,7 +82,7 @@ class FakeIntegerIterator final : public TableRowIterator {
   size_t m_current_index{0};
   int m_num_read_calls{0};
   Field_long *m_field;
-  std::vector<int> m_dataset;
+  std::vector<std::optional<int>> m_dataset;
 };
 
 #endif  // UNITTEST_GUNIT_FAKE_INTEGER_ITERATOR_H_

--- a/unittest/gunit/hash_join-t.cc
+++ b/unittest/gunit/hash_join-t.cc
@@ -20,8 +20,10 @@
    along with this program; if not, write to the Free Software
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
+#include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <random>
 #include <unordered_set>
 #include <vector>
@@ -48,6 +50,10 @@
 #include "unittest/gunit/test_utils.h"
 
 using pack_rows::TableCollection;
+using std::nullopt;
+using std::optional;
+using std::vector;
+using testing::UnorderedElementsAre;
 
 namespace hash_join_unittest {
 
@@ -273,6 +279,30 @@ class HashJoinTestHelper {
   }
 
   HashJoinTestHelper(Server_initializer *initializer,
+                     vector<optional<int>> left_dataset,
+                     vector<optional<int>> right_dataset,
+                     bool is_nullable) {
+    m_left_table_field.reset(new (&m_mem_root) Mock_field_long(
+        "column1", is_nullable, false));
+    m_left_table.reset(new (&m_mem_root) Fake_TABLE(m_left_table_field.get()));
+
+    m_right_table_field.reset(new (&m_mem_root) Mock_field_long(
+        "column1", is_nullable, false));
+    m_right_table.reset(new (&m_mem_root)
+                            Fake_TABLE(m_right_table_field.get()));
+    SetupFakeTables(initializer);
+
+    left_iterator.reset(new (&m_mem_root) FakeIntegerIterator(
+        initializer->thd(), m_left_table.get(),
+        down_cast<Field_long *>(m_left_table->field[0]),
+        std::move(left_dataset)));
+    right_iterator.reset(new (&m_mem_root) FakeIntegerIterator(
+        initializer->thd(), m_right_table.get(),
+        down_cast<Field_long *>(m_right_table->field[0]),
+        std::move(right_dataset)));
+  }
+
+  HashJoinTestHelper(Server_initializer *initializer,
                      const vector<std::string> &left_dataset,
                      const vector<std::string> &right_dataset)
       : extra_conditions(*THR_MALLOC) {
@@ -348,6 +378,21 @@ class HashJoinTestHelper {
   unique_ptr_destroy_only<Field> m_left_table_field;
   unique_ptr_destroy_only<Field> m_right_table_field;
 };
+
+static vector<optional<int>> CollectIntResults(HashJoinIterator *iterator,
+                                               Field *field) {
+  vector<optional<int>> results;
+  int error;
+  while ((error = iterator->Read()) == 0) {
+    if (field->is_null()) {
+      results.emplace_back(nullopt);
+    } else {
+      results.emplace_back(field->val_int());
+    }
+  }
+  EXPECT_EQ(-1, error);  // EOF
+  return results;
+}
 
 TEST(HashJoinTest, InnerJoinIntOneToOneMatch) {
   my_testing::Server_initializer initializer;
@@ -751,6 +796,54 @@ TEST(HashJoinTest, AntiJoinInt) {
   EXPECT_EQ(-1, hash_join_iterator.Read());
 
   initializer.TearDown();
+}
+
+// Test that antijoin works correctly when the hash table spills to disk.
+TEST(HashJoinTest, AntiJoinIntSpillToDisk) {
+  my_testing::Server_initializer initializer;
+  initializer.SetUp();
+
+  vector<optional<int>> probe_data = {
+      1, 2, 3, 4, 1998, 1999, 2000, 2001, -1, -2, nullopt, nullopt, 2, 3, 4};
+
+  vector<optional<int>> build_data;
+  build_data.emplace_back(nullopt);
+  for (int i = 0; i < 1000; ++i) {
+    build_data.emplace_back(i * 2);
+  }
+
+  HashJoinTestHelper test_helper{&initializer, build_data, probe_data,
+                                 /*is_nullable=*/true};
+
+  // The iterator will execute something that is equivalent to the query
+  // "SELECT * FROM probe_data WHERE a NOT IN (SELECT b FROM build_data);"
+  // We set max_memory_available so low that build_data doesn't fit in the join
+  // buffer and spills to disk.
+  HashJoinIterator hash_join_iterator{initializer.thd(),
+                                      std::move(test_helper.left_iterator),
+                                      test_helper.left_tables(),
+                                      static_cast<double>(build_data.size()),
+                                      std::move(test_helper.right_iterator),
+                                      test_helper.right_tables(),
+                                      /*store_rowids=*/false,
+                                      /*tables_to_get_rowid_for=*/0,
+                                      /*max_memory_available=*/128,
+                                      {*test_helper.join_condition},
+                                      /*allow_spill_to_disk=*/true,
+                                      JoinType::ANTI,
+                                      test_helper.extra_conditions,
+                                      /*probe_input_batch_mode=*/false,
+                                      /*hash_table_generation=*/nullptr};
+
+  ASSERT_FALSE(hash_join_iterator.Init());
+
+  EXPECT_GT(hash_join_iterator.ChunkCount(), 0)
+      << "The hash table didn't spill to disk.";
+
+  EXPECT_THAT(CollectIntResults(&hash_join_iterator,
+                                test_helper.right_qep_tab->table()->field[0]),
+              UnorderedElementsAre(nullopt, nullopt, -1, -2, 1, 3, 3, 1999,
+                                   2000, 2001));
 }
 
 TEST(HashJoinTest, LeftHashJoinInt) {


### PR DESCRIPTION
Bug#37161583: Incorrect result with LEFT JOIN and small join_buffer_size

Wrong results were returned for some queries that used hash antijoin when the hash table didn't fit in the join buffer and spilled to disk. (The bug title says LEFT JOIN, but the bug is actually in the antijoin handling. The query in the bug report used LEFT JOIN, but it was transformed internally from a left outer join to an antijoin.)

The problem was that some rows in the probe table were skipped when writing the probe rows to chunk files. The skipped rows were those that had a NULL value in a part of the join key. Such rows are fine to skip for inner joins and semijoins, as they are known to have no match in the build table. For outer joins and antijoins, however, the rows in the probe table that have no matching row in the build table, should be part of the join result, so they must be included in the chunk files.

There was already logic for preserving these rows in the chunk files for outer joins. This patch extends the logic so that it also covers antijoins.

Change-Id: Iee4ab58d549b0c653a893ec18542adbf6130c4d6 (cherry picked from commit 01c8e25ddc441f3df4169352b5c4b76484043690)