### PR TITLE
[optimization] Accelerate my_convert ASCII handling on AArch64 with NEON

### DIFF
--- a/strings/ctype.cc
+++ b/strings/ctype.cc
@@ -33,6 +33,10 @@
 
 #include <algorithm>
 
+#if defined(__aarch64__)
+#include <arm_neon.h>
+#endif
+
 #include "m_ctype.h"
 #include "m_string.h"
 #include "my_byteorder.h"
@@ -951,6 +955,18 @@ size_t my_convert(char *to, size_t to_length, const CHARSET_INFO *to_cs,
                                errors);
 
   length = length2 = std::min(to_length, from_length);
+
+#if defined(__aarch64__)
+  for (; length >= 16; length -= 16, from += 16, to += 16) {
+    const uint8x16_t bytes =
+        vld1q_u8(reinterpret_cast<const uint8_t *>(from));
+    const uint64x2_t high_bits = vreinterpretq_u64_u8(bytes);
+    if ((vgetq_lane_u64(high_bits, 0) | vgetq_lane_u64(high_bits, 1)) &
+        0x8080808080808080ULL)
+      break;
+    vst1q_u8(reinterpret_cast<uint8_t *>(to), bytes);
+  }
+#endif
 
 #if defined(__i386__) || defined(_WIN32) || defined(__x86_64__) || \
     defined(__aarch64__)


### PR DESCRIPTION
[optimization] Accelerate my_convert ASCII handling on AArch64 with NEON
- Add an AArch64-only 16-byte NEON ASCII prefix loop in strings/ctype.cc
- Preserve the existing 4-byte fast path and generic scalar fallback logic

[优化] 在 AArch64 上使用 NEON 加速 my_convert 的 ASCII 处理
- 在 `strings/ctype.cc` 中新增针对 AArch64 的 16 字节 NEON ASCII 前缀循环
- 保留现有的 4 字节快速路径以及通用标量回退逻辑

By applying vectorization optimizations to `my_convert()` on the new Kunpeng 920 CPU model, the average performance in the Sysbench read-only workload is improved by 2%.
通过在鲲鹏920新型号CPU上使用my_convert()向量化优化，可以使Sysbench只读场景平均性能提升2%。

<img width="728" height="400" alt="image" src="https://github.com/user-attachments/assets/1a9b922d-3f9c-447e-9456-3c9b025687c2" />
